### PR TITLE
⚡ perf: Batch insert apps in autoPopulateCategory

### DIFF
--- a/lib/providers/apps_service.dart
+++ b/lib/providers/apps_service.dart
@@ -513,10 +513,26 @@ class AppsService extends ChangeNotifier
         return; // Not a special category
     }
     
+    if (appsToAdd.isEmpty) {
+      return;
+    }
+
+    int nextOrder = await _database.nextAppCategoryOrder(actualCategory.id) ?? 0;
+    List<AppsCategoriesCompanion> batch = [];
+
     for (final app in appsToAdd) {
-      await addToCategory(app, actualCategory, shouldNotifyListeners: false);
+      batch.add(AppsCategoriesCompanion.insert(
+        categoryId: actualCategory.id,
+        appPackageName: app.packageName,
+        order: nextOrder,
+      ));
+      app.categoryOrders[actualCategory.id] = nextOrder;
+      actualCategory.applications.add(app);
+      nextOrder++;
     }
     
+    await _database.insertAppsCategories(batch);
+    sortCategory(actualCategory);
     notifyListeners();
   }
 


### PR DESCRIPTION
💡 **What:** Replaced the loop that calls `addToCategory` individually with a batch operation. It now calculates the `nextOrder` once, builds a list of `AppsCategoriesCompanion` objects, updates local in-memory models (`categoryOrders` and `applications`), and executes a single `insertAppsCategories` batch insert. Finally, it sorts the category once.

🎯 **Why:** The previous implementation executed two database operations per app (`nextAppCategoryOrder` and `insertAppsCategories`), resulting in an N+1 Query scenario. With a large number of apps to add, this caused significant overhead.

📊 **Measured Improvement:** We attempted to measure this by compiling a dedicated Flutter test file, but due to several out-of-date and missing types (e.g., `CategoryWithApps` is mysteriously unresolvable in the project's tests), it was impractical to get a running benchmark. However, theoretically, moving from $O(n)$ queries to $O(1)$ queries is fundamentally faster for database I/O, especially when $n$ is large. We avoid $n$ repeated calls to `nextAppCategoryOrder` and $n$ individual insert operations.

---
*PR created automatically by Jules for task [2200983088081003478](https://jules.google.com/task/2200983088081003478) started by @LeanBitLab*