### PR TITLE
🧪 Add unit tests for NetworkService.getWifiUsageForPeriod

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.2"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.4.1"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -130,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -162,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -178,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -218,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.6"
   drift:
     dependency: "direct main"
     description:
@@ -250,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -486,10 +481,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -518,26 +513,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -554,38 +549,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -646,10 +633,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -902,7 +889,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -955,10 +942,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   storage_inspector:
     dependency: transitive
     description:
@@ -971,10 +958,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -1011,10 +998,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.9"
   timing:
     dependency: transitive
     description:
@@ -1067,10 +1054,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1144,5 +1131,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.5"

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -737,6 +737,43 @@ class MockAppsService extends _i1.Mock implements _i15.AppsService {
       ) as _i9.Future<_i13.Uint8List>);
 
   @override
+  _i9.Future<void> setCustomAppBanner(
+    String? packageName,
+    String? imagePath,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setCustomAppBanner,
+          [
+            packageName,
+            imagePath,
+          ],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> removeCustomAppBanner(String? packageName) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #removeCustomAppBanner,
+          [packageName],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<bool> hasCustomBanner(String? packageName) => (super.noSuchMethod(
+        Invocation.method(
+          #hasCustomBanner,
+          [packageName],
+        ),
+        returnValue: _i9.Future<bool>.value(false),
+      ) as _i9.Future<bool>);
+
+  @override
   _i9.Future<_i13.Uint8List> getAppIcon(String? packageName) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1265,6 +1302,30 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as bool);
 
   @override
+  bool get showAppNamesBelowIcons => (super.noSuchMethod(
+        Invocation.getter(#showAppNamesBelowIcons),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get squareBannerShapeEnabled => (super.noSuchMethod(
+        Invocation.getter(#squareBannerShapeEnabled),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get hideHighlightOutlineOnHomescreen => (super.noSuchMethod(
+        Invocation.getter(#hideHighlightOutlineOnHomescreen),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get appSelectorTransitionAnimationEnabled => (super.noSuchMethod(
+        Invocation.getter(#appSelectorTransitionAnimationEnabled),
+        returnValue: false,
+      ) as bool);
+
+  @override
   bool get showDateInStatusBar => (super.noSuchMethod(
         Invocation.getter(#showDateInStatusBar),
         returnValue: false,
@@ -1453,6 +1514,49 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
         Invocation.method(
           #setShowCategoryTitles,
           [show],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> setShowAppNamesBelowIcons(bool? show) => (super.noSuchMethod(
+        Invocation.method(
+          #setShowAppNamesBelowIcons,
+          [show],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> setSquareBannerShapeEnabled(bool? enabled) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setSquareBannerShapeEnabled,
+          [enabled],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> setHideHighlightOutlineOnHomescreen(bool? enabled) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setHideHighlightOutlineOnHomescreen,
+          [enabled],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> setAppSelectorTransitionAnimationEnabled(bool? enabled) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setAppSelectorTransitionAnimationEnabled,
+          [enabled],
         ),
         returnValue: _i9.Future<void>.value(),
         returnValueForMissingStub: _i9.Future<void>.value(),

--- a/test/providers/network_service_test.dart
+++ b/test/providers/network_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flauncher/providers/network_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mocks.mocks.dart';
+
+void main() {
+  late MockFLauncherChannel mockChannel;
+  late NetworkService networkService;
+
+  setUp(() {
+    mockChannel = MockFLauncherChannel();
+    when(mockChannel.getActiveNetworkInformation())
+        .thenAnswer((_) async => <String, dynamic>{});
+    when(mockChannel.checkUsageStatsPermission())
+        .thenAnswer((_) async => false);
+    networkService = NetworkService(mockChannel);
+  });
+
+  group('getWifiUsageForPeriod', () {
+    test('returns daily usage when period is "daily"', () async {
+      when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+
+      final result = await networkService.getWifiUsageForPeriod('daily');
+
+      expect(result, 100);
+      verify(mockChannel.getDailyWifiUsage()).called(1);
+      verifyNever(mockChannel.getWeeklyWifiUsage());
+      verifyNever(mockChannel.getMonthlyWifiUsage());
+    });
+
+    test('returns weekly usage when period is "weekly"', () async {
+      when(mockChannel.getWeeklyWifiUsage()).thenAnswer((_) async => 500);
+
+      final result = await networkService.getWifiUsageForPeriod('weekly');
+
+      expect(result, 500);
+      verify(mockChannel.getWeeklyWifiUsage()).called(1);
+      verifyNever(mockChannel.getDailyWifiUsage());
+      verifyNever(mockChannel.getMonthlyWifiUsage());
+    });
+
+    test('returns monthly usage when period is "monthly"', () async {
+      when(mockChannel.getMonthlyWifiUsage()).thenAnswer((_) async => 2000);
+
+      final result = await networkService.getWifiUsageForPeriod('monthly');
+
+      expect(result, 2000);
+      verify(mockChannel.getMonthlyWifiUsage()).called(1);
+      verifyNever(mockChannel.getDailyWifiUsage());
+      verifyNever(mockChannel.getWeeklyWifiUsage());
+    });
+
+    test('returns daily usage when period is unknown', () async {
+      when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+
+      final result = await networkService.getWifiUsageForPeriod('unknown_period');
+
+      expect(result, 100);
+      verify(mockChannel.getDailyWifiUsage()).called(1);
+      verifyNever(mockChannel.getWeeklyWifiUsage());
+      verifyNever(mockChannel.getMonthlyWifiUsage());
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The missing tests for `NetworkService.getWifiUsageForPeriod` have been implemented.
📊 **Coverage:** The test coverage now includes the 'daily', 'weekly', 'monthly', and default/unknown period scenarios to guarantee correct delegation to the underlying `FLauncherChannel`.
✨ **Result:** Improved test coverage and reliability for network usage fetching.

---
*PR created automatically by Jules for task [5868886514666042722](https://jules.google.com/task/5868886514666042722) started by @LeanBitLab*