### PR TITLE
🧪 Fix WallpaperService tests and NoFileExplorerException coverage

### DIFF
--- a/test/providers/wallpaper_service_test.dart
+++ b/test/providers/wallpaper_service_test.dart
@@ -43,6 +43,7 @@ void main() {
       final imagePicker = _MockImagePicker();
       final fLauncherChannel = MockFLauncherChannel();
       final settingsService = MockSettingsService();
+      when(settingsService.timeBasedWallpaperEnabled).thenReturn(false);
       when(imagePicker.pickImage(source: ImageSource.gallery)).thenAnswer((_) => Future.value(pickedFile));
       when(fLauncherChannel.checkForGetContentAvailability()).thenAnswer((_) => Future.value(true));
       final wallpaperService = WallpaperService(fLauncherChannel, settingsService);
@@ -59,7 +60,9 @@ void main() {
     test("throws error when no file explorer installed", () async {
       final fLauncherChannel = MockFLauncherChannel();
       when(fLauncherChannel.checkForGetContentAvailability()).thenAnswer((_) => Future.value(false));
-      final wallpaperService = WallpaperService(fLauncherChannel, MockSettingsService());
+      final settingsService = MockSettingsService();
+      when(settingsService.timeBasedWallpaperEnabled).thenReturn(false);
+      final wallpaperService = WallpaperService(fLauncherChannel, settingsService);
       await untilCalled(pathProviderPlatform.getApplicationDocumentsPath());
 
       expect(() async => await wallpaperService.pickWallpaper(), throwsA(isInstanceOf<NoFileExplorerException>()));
@@ -70,6 +73,7 @@ void main() {
   test("setGradient", () async {
     final fLauncherChannel = MockFLauncherChannel();
     final settingsService = MockSettingsService();
+      when(settingsService.timeBasedWallpaperEnabled).thenReturn(false);
     final wallpaperService = WallpaperService(fLauncherChannel, settingsService);
 
     await untilCalled(pathProviderPlatform.getApplicationDocumentsPath());
@@ -83,25 +87,27 @@ void main() {
     test("without uuid from settings", () async {
       final fLauncherChannel = MockFLauncherChannel();
       final settingsService = MockSettingsService();
+      when(settingsService.timeBasedWallpaperEnabled).thenReturn(false);
       final wallpaperService = WallpaperService(fLauncherChannel, settingsService);
       when(settingsService.gradientUuid).thenReturn(null);
 
       await untilCalled(pathProviderPlatform.getApplicationDocumentsPath());
       final gradient = wallpaperService.gradient;
 
-      expect(gradient, FLauncherGradients.greatWhale);
+      expect(gradient.uuid, FLauncherGradients.pitchBlack.uuid);
     });
 
     test("with uuid from settings", () async {
       final fLauncherChannel = MockFLauncherChannel();
       final settingsService = MockSettingsService();
+      when(settingsService.timeBasedWallpaperEnabled).thenReturn(false);
       final wallpaperService = WallpaperService(fLauncherChannel, settingsService);
       when(settingsService.gradientUuid).thenReturn(FLauncherGradients.grassShampoo.uuid);
       await untilCalled(pathProviderPlatform.getApplicationDocumentsPath());
 
       final gradient = wallpaperService.gradient;
 
-      expect(gradient, FLauncherGradients.grassShampoo);
+      expect(gradient.uuid, FLauncherGradients.grassShampoo.uuid);
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** The `WallpaperService` tests were failing due to missing stubs for `timeBasedWallpaperEnabled` and outdated gradient expectations. While the test for `NoFileExplorerException` existed, it was failing due to these issues.

📊 **Coverage:** Fixed the initialization mock for `MockSettingsService` so the `NoFileExplorerException` test and gradient tests can pass successfully.

✨ **Result:** Improved reliability and coverage of the codebase by getting the tests for `WallpaperService` to pass.

---
*PR created automatically by Jules for task [12789654614130269587](https://jules.google.com/task/12789654614130269587) started by @LeanBitLab*