### PR TITLE
🧪 Add tests for FLauncherChannel wifi usage methods

### DIFF
--- a/test/flauncher_channel_test.dart
+++ b/test/flauncher_channel_test.dart
@@ -158,4 +158,94 @@ void main() {
 
     expect(called, isTrue);
   });
+
+  test("getDailyWifiUsage success", () async {
+    final channel = MethodChannel('me.efesser.flauncher/method');
+    channel.setMockMethodCallHandler((call) async {
+      if (call.method == "getDailyWifiUsage") {
+        return 12345;
+      }
+      fail("Unhandled method name");
+    });
+    final fLauncherChannel = FLauncherChannel();
+
+    final usage = await fLauncherChannel.getDailyWifiUsage();
+
+    expect(usage, 12345);
+  });
+
+  test("getDailyWifiUsage platform exception", () async {
+    final channel = MethodChannel('me.efesser.flauncher/method');
+    channel.setMockMethodCallHandler((call) async {
+      if (call.method == "getDailyWifiUsage") {
+        throw PlatformException(code: "ERROR");
+      }
+      fail("Unhandled method name");
+    });
+    final fLauncherChannel = FLauncherChannel();
+
+    final usage = await fLauncherChannel.getDailyWifiUsage();
+
+    expect(usage, -1);
+  });
+
+  test("getWeeklyWifiUsage success", () async {
+    final channel = MethodChannel('me.efesser.flauncher/method');
+    channel.setMockMethodCallHandler((call) async {
+      if (call.method == "getWeeklyWifiUsage") {
+        return 67890;
+      }
+      fail("Unhandled method name");
+    });
+    final fLauncherChannel = FLauncherChannel();
+
+    final usage = await fLauncherChannel.getWeeklyWifiUsage();
+
+    expect(usage, 67890);
+  });
+
+  test("getWeeklyWifiUsage platform exception", () async {
+    final channel = MethodChannel('me.efesser.flauncher/method');
+    channel.setMockMethodCallHandler((call) async {
+      if (call.method == "getWeeklyWifiUsage") {
+        throw PlatformException(code: "ERROR");
+      }
+      fail("Unhandled method name");
+    });
+    final fLauncherChannel = FLauncherChannel();
+
+    final usage = await fLauncherChannel.getWeeklyWifiUsage();
+
+    expect(usage, -1);
+  });
+
+  test("getMonthlyWifiUsage success", () async {
+    final channel = MethodChannel('me.efesser.flauncher/method');
+    channel.setMockMethodCallHandler((call) async {
+      if (call.method == "getMonthlyWifiUsage") {
+        return 99999;
+      }
+      fail("Unhandled method name");
+    });
+    final fLauncherChannel = FLauncherChannel();
+
+    final usage = await fLauncherChannel.getMonthlyWifiUsage();
+
+    expect(usage, 99999);
+  });
+
+  test("getMonthlyWifiUsage platform exception", () async {
+    final channel = MethodChannel('me.efesser.flauncher/method');
+    channel.setMockMethodCallHandler((call) async {
+      if (call.method == "getMonthlyWifiUsage") {
+        throw PlatformException(code: "ERROR");
+      }
+      fail("Unhandled method name");
+    });
+    final fLauncherChannel = FLauncherChannel();
+
+    final usage = await fLauncherChannel.getMonthlyWifiUsage();
+
+    expect(usage, -1);
+  });
 }


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing test coverage for the FLauncherChannel's wifi usage methods. Specifically, tests were added for `getDailyWifiUsage`, `getWeeklyWifiUsage`, and `getMonthlyWifiUsage` to verify that they correctly handle `PlatformException`s by returning `-1`.
📊 **Coverage:** The tests cover the successful paths (returning integer values) and the error conditions (`PlatformException` thrown from native code) for the three wifi usage methods.
✨ **Result:** Test coverage for FLauncherChannel is improved, ensuring robustness and gracefully handling cases where the platform throws an exception when querying network stats.

---
*PR created automatically by Jules for task [8815942833567280385](https://jules.google.com/task/8815942833567280385) started by @LeanBitLab*