### PR TITLE
🧪 Add tests for BrightnessService.requestPermission error handling

### DIFF
--- a/test/providers/brightness_service_test.dart
+++ b/test/providers/brightness_service_test.dart
@@ -1,0 +1,60 @@
+import 'package:flauncher/providers/brightness_service.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('me.efesser.flauncher/method');
+
+  setUp(() async {
+    SharedPreferencesStorePlatform.instance = InMemorySharedPreferencesStore.empty();
+  });
+
+  group('BrightnessService requestPermission', () {
+    test('handles successful permission request', () async {
+      bool methodCalled = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'requestWriteSettingsPermission') {
+            methodCalled = true;
+            return null;
+          }
+          if (methodCall.method == 'checkWriteSettingsPermission') {
+            return true;
+          }
+          return null;
+        },
+      );
+
+      final sharedPreferences = await SharedPreferences.getInstance();
+      final service = BrightnessService(sharedPreferences);
+
+      await service.requestPermission();
+      expect(methodCalled, isTrue);
+    });
+
+    test('catches and handles PlatformException', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'requestWriteSettingsPermission') {
+            throw PlatformException(code: 'ERROR', message: 'Test error');
+          }
+          if (methodCall.method == 'checkWriteSettingsPermission') {
+            return true;
+          }
+          return null;
+        },
+      );
+
+      final sharedPreferences = await SharedPreferences.getInstance();
+      final service = BrightnessService(sharedPreferences);
+
+      // Should not throw
+      await service.requestPermission();
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `BrightnessService.requestPermission` error handling is addressed.
📊 **Coverage:** The happy path for permission requests and the specific scenario where a `PlatformException` is thrown by the method channel are now tested.
✨ **Result:** Enhanced test coverage and ensured regression safety around native permission request error scenarios.

---
*PR created automatically by Jules for task [7864520751657570525](https://jules.google.com/task/7864520751657570525) started by @LeanBitLab*