### PR TITLE
feat: support multiple app banner shapes for various TV OSes

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -81,7 +81,7 @@
     "settings": "Settings",
     "show": "Show",
     "showCategoryTitles": "Show category titles",
-    "squareAppBanners": "Square App Banners",
+    "appBannerShape": "App Banner Shape",
     "hideHighlightOutlineOnHomescreen": "Hide highlight outline on homescreen",
     "appSelectorTransitionAnimation": "App selector transition animation",
     "sort": "Sort",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -80,7 +80,7 @@
     "settings": "Ajustes",
     "show": "Mostrar",
     "showCategoryTitles": "Mostrar títulos de categorías",
-    "squareAppBanners": "Banners de aplicaciones cuadrados",
+    "appBannerShape": "Forma de los banners de aplicaciones",
     "hideHighlightOutlineOnHomescreen": "Ocultar el contorno de resaltado en la pantalla de inicio",
     "appSelectorTransitionAnimation": "Animación de transición del selector de aplicaciones",
     "sort": "Orden",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es')
+    Locale('es'),
   ];
 
   /// No description provided for @aboutFlauncher.
@@ -434,11 +434,11 @@ abstract class AppLocalizations {
   /// **'Show category titles'**
   String get showCategoryTitles;
 
-  /// No description provided for @squareAppBanners.
+  /// No description provided for @appBannerShape.
   ///
   /// In en, this message translates to:
-  /// **'Square App Banners'**
-  String get squareAppBanners;
+  /// **'App Banner Shape'**
+  String get appBannerShape;
 
   /// No description provided for @hideHighlightOutlineOnHomescreen.
   ///
@@ -576,8 +576,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -187,7 +187,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showCategoryTitles => 'Show category titles';
 
   @override
-  String get squareAppBanners => 'Square App Banners';
+  String get appBannerShape => 'App Banner Shape';
 
   @override
   String get hideHighlightOutlineOnHomescreen =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -190,7 +190,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showCategoryTitles => 'Mostrar títulos de categorías';
 
   @override
-  String get squareAppBanners => 'Banners de aplicaciones cuadrados';
+  String get appBannerShape => 'Forma de los banners de aplicaciones';
 
   @override
   String get hideHighlightOutlineOnHomescreen =>

--- a/lib/providers/settings_service.dart
+++ b/lib/providers/settings_service.dart
@@ -31,7 +31,7 @@ const _backButtonAction = "back_button_action";
 const _dateFormat = "date_format";
 const _showCategoryTitles = "show_category_titles";
 const _showAppNamesBelowIcons = "show_app_names_below_icons";
-const _squareBannerShapeEnabled = "square_banner_shape_enabled";
+const _appBannerShape = "app_banner_shape";
 const _hideHighlightOutlineOnHomescreen = "hide_highlight_outline_on_homescreen";
 const _appSelectorTransitionAnimationEnabled = "app_selector_transition_animation_enabled";
 const _showDateInStatusBar = "show_date_in_status_bar";
@@ -81,7 +81,7 @@ class SettingsService extends ChangeNotifier {
 
   bool get showAppNamesBelowIcons => _sharedPreferences.getBool(_showAppNamesBelowIcons) ?? false;
 
-  bool get squareBannerShapeEnabled => _sharedPreferences.getBool(_squareBannerShapeEnabled) ?? false;
+  String get appBannerShape => _sharedPreferences.getString(_appBannerShape) ?? "google_tv";
 
   bool get hideHighlightOutlineOnHomescreen => _sharedPreferences.getBool(_hideHighlightOutlineOnHomescreen) ?? false;
 
@@ -161,8 +161,9 @@ class SettingsService extends ChangeNotifier {
     return set(_showAppNamesBelowIcons, show);
   }
 
-  Future<void> setSquareBannerShapeEnabled(bool enabled) async {
-    return set(_squareBannerShapeEnabled, enabled);
+  Future<void> setAppBannerShape(String shape) async {
+    await _sharedPreferences.setString(_appBannerShape, shape);
+    notifyListeners();
   }
 
   Future<void> setHideHighlightOutlineOnHomescreen(bool enabled) async {

--- a/lib/widgets/app_card.dart
+++ b/lib/widgets/app_card.dart
@@ -141,12 +141,33 @@ class _AppCardState extends State<AppCard> with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final bool showAppNames = context.select<SettingsService, bool>((s) => s.showAppNamesBelowIcons);
-    final bool squareBannerShapeEnabled = context.select<SettingsService, bool>((s) => s.squareBannerShapeEnabled);
+    final String appBannerShape = context.select<SettingsService, String>((s) => s.appBannerShape);
     final bool hideHighlightOutlineOnHomescreen = context.select<SettingsService, bool>((s) => s.hideHighlightOutlineOnHomescreen);
     final bool appSelectorTransitionAnimationEnabled = context.select<SettingsService, bool>((s) => s.appSelectorTransitionAnimationEnabled);
 
-    final BorderRadius borderRadius = squareBannerShapeEnabled ? BorderRadius.zero : BorderRadius.circular(8);
-    final BorderRadius innerBorderRadius = squareBannerShapeEnabled ? BorderRadius.zero : BorderRadius.circular(6);
+    BorderRadius borderRadius;
+    BorderRadius innerBorderRadius;
+
+    switch (appBannerShape) {
+      case 'apple_tv':
+        borderRadius = BorderRadius.circular(16);
+        innerBorderRadius = BorderRadius.circular(14);
+        break;
+      case 'roku_os':
+      case 'fire_os':
+        borderRadius = BorderRadius.zero;
+        innerBorderRadius = BorderRadius.zero;
+        break;
+      case 'web_os':
+        borderRadius = BorderRadius.circular(100);
+        innerBorderRadius = BorderRadius.circular(98);
+        break;
+      case 'google_tv':
+      default:
+        borderRadius = BorderRadius.circular(8);
+        innerBorderRadius = BorderRadius.circular(6);
+        break;
+    }
 
     return FocusKeyboardListener(
       onPressed: (key) => _onPressed(context, key),

--- a/lib/widgets/settings/app_banner_shape_page.dart
+++ b/lib/widgets/settings/app_banner_shape_page.dart
@@ -1,0 +1,199 @@
+/*
+ * FLauncher
+ * Copyright (C) 2024 LeanBitLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../../providers/settings_service.dart';
+
+class AppBannerShapePage extends StatelessWidget {
+  static const String routeName = "app_banner_shape_panel";
+
+  const AppBannerShapePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+
+    return Selector<SettingsService, String>(
+      selector: (_, settingsService) => settingsService.appBannerShape,
+      builder: (context, currentShape, _) {
+        final settingsService = context.read<SettingsService>();
+
+        return Column(
+          children: [
+            Text(localizations.appBannerShape, style: Theme.of(context).textTheme.titleLarge),
+            const Divider(),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    _ShapeRadioTile(
+                      title: 'Google TV / Android TV',
+                      subtitle: 'Rounded corners (8px)',
+                      value: 'google_tv',
+                      groupValue: currentShape,
+                      onChanged: (value) => settingsService.setAppBannerShape(value!),
+                      autofocus: currentShape == 'google_tv',
+                    ),
+                    _ShapeRadioTile(
+                      title: 'Apple TV (tvOS)',
+                      subtitle: 'Larger rounded corners (16px)',
+                      value: 'apple_tv',
+                      groupValue: currentShape,
+                      onChanged: (value) => settingsService.setAppBannerShape(value!),
+                      autofocus: currentShape == 'apple_tv',
+                    ),
+                    _ShapeRadioTile(
+                      title: 'Roku OS / Fire OS',
+                      subtitle: 'Square corners (0px)',
+                      value: 'roku_os',
+                      groupValue: currentShape,
+                      onChanged: (value) => settingsService.setAppBannerShape(value!),
+                      autofocus: currentShape == 'roku_os' || currentShape == 'fire_os',
+                    ),
+                    _ShapeRadioTile(
+                      title: 'LG WebOS / Tizen',
+                      subtitle: 'Circular / Pill shape',
+                      value: 'web_os',
+                      groupValue: currentShape,
+                      onChanged: (value) => settingsService.setAppBannerShape(value!),
+                      autofocus: currentShape == 'web_os',
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ShapeRadioTile extends StatefulWidget {
+  final String title;
+  final String subtitle;
+  final String value;
+  final String groupValue;
+  final ValueChanged<String?> onChanged;
+  final bool autofocus;
+
+  const _ShapeRadioTile({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.groupValue,
+    required this.onChanged,
+    this.autofocus = false,
+  });
+
+  @override
+  State<_ShapeRadioTile> createState() => _ShapeRadioTileState();
+}
+
+class _ShapeRadioTileState extends State<_ShapeRadioTile> {
+  bool _hasFocus = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final isSelected = widget.value == widget.groupValue;
+    final primaryColor = Theme.of(context).colorScheme.primary;
+
+    return RepaintBoundary(
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: (_) {
+            widget.onChanged(widget.value);
+            return null;
+          }),
+          ButtonActivateIntent: CallbackAction<ButtonActivateIntent>(onInvoke: (_) {
+            widget.onChanged(widget.value);
+            return null;
+          }),
+        },
+        child: Focus(
+          autofocus: widget.autofocus,
+          onFocusChange: (hasFocus) {
+            setState(() {
+              _hasFocus = hasFocus;
+            });
+            if (hasFocus) {
+              Scrollable.ensureVisible(
+                context,
+                alignment: 0.5,
+                duration: const Duration(milliseconds: 100),
+                curve: Curves.easeOut,
+              );
+            }
+          },
+          child: InkWell(
+            onTap: () {
+              widget.onChanged(widget.value);
+            },
+            focusColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            child: Container(
+              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: _hasFocus ? Colors.white.withOpacity(0.05) : Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                border: _hasFocus
+                    ? Border.all(color: primaryColor, width: 2)
+                    : Border.all(color: Colors.transparent, width: 2),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.title,
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                            color: isSelected ? Colors.white : Colors.white70,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          widget.subtitle,
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Colors.white54,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (isSelected)
+                    Icon(Icons.check_circle, color: primaryColor)
+                  else
+                    Icon(Icons.circle_outlined, color: Colors.white38),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/settings/misc_panel_page.dart
+++ b/lib/widgets/settings/misc_panel_page.dart
@@ -1,6 +1,8 @@
 
 import 'package:flauncher/providers/settings_service.dart';
 import 'package:flauncher/widgets/rounded_switch_list_tile.dart';
+import 'package:flauncher/widgets/settings/focusable_settings_tile.dart';
+import 'package:flauncher/widgets/settings/app_banner_shape_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -48,11 +50,10 @@ class MiscPanelPage extends StatelessWidget {
                 title: Text("Show App Names Below Icons", style: Theme.of(context).textTheme.bodyMedium),
                 secondary: Icon(Icons.subtitles),
               ),
-              RoundedSwitchListTile(
-                value: settingsService.squareBannerShapeEnabled,
-                onChanged: (value) => settingsService.setSquareBannerShapeEnabled(value),
-                title: Text(localizations.squareAppBanners, style: Theme.of(context).textTheme.bodyMedium),
-                secondary: Icon(Icons.crop_square),
+              FocusableSettingsTile(
+                leading: Icon(Icons.crop_square),
+                title: Text(localizations.appBannerShape, style: Theme.of(context).textTheme.bodyMedium),
+                onPressed: () => Navigator.of(context).pushNamed(AppBannerShapePage.routeName),
               ),
               RoundedSwitchListTile(
                 value: settingsService.hideHighlightOutlineOnHomescreen,

--- a/lib/widgets/settings/settings_panel.dart
+++ b/lib/widgets/settings/settings_panel.dart
@@ -34,6 +34,7 @@ import 'package:flauncher/widgets/settings/misc_panel_page.dart';
 import 'package:flauncher/widgets/settings/interface_settings_page.dart';
 import 'package:flauncher/widgets/settings/general_settings_page.dart';
 import 'package:flauncher/widgets/settings/screensaver_clock_style_page.dart';
+import 'package:flauncher/widgets/settings/app_banner_shape_page.dart';
 import 'package:flauncher/models/app.dart';
 import 'package:flutter/material.dart';
 
@@ -100,6 +101,8 @@ class _SettingsPanelState extends State<SettingsPanel> {
                       return _FastPageRoute(builder: (_) => MiscPanelPage());
                     case ScreensaverClockStylePage.routeName:
                       return _FastPageRoute(builder: (_) => const ScreensaverClockStylePage());
+                    case AppBannerShapePage.routeName:
+                      return _FastPageRoute(builder: (_) => const AppBannerShapePage());
                     case AccentColorPage.routeName:
                       return _FastPageRoute(builder: (_) => AccentColorPage());
                     case BrightnessSettingsPage.routeName:

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -1308,10 +1308,13 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as bool);
 
   @override
-  bool get squareBannerShapeEnabled => (super.noSuchMethod(
-        Invocation.getter(#squareBannerShapeEnabled),
-        returnValue: false,
-      ) as bool);
+  String get appBannerShape => (super.noSuchMethod(
+        Invocation.getter(#appBannerShape),
+        returnValue: _i18.dummyValue<String>(
+          this,
+          Invocation.getter(#appBannerShape),
+        ),
+      ) as String);
 
   @override
   bool get hideHighlightOutlineOnHomescreen => (super.noSuchMethod(
@@ -1530,11 +1533,10 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as _i9.Future<void>);
 
   @override
-  _i9.Future<void> setSquareBannerShapeEnabled(bool? enabled) =>
-      (super.noSuchMethod(
+  _i9.Future<void> setAppBannerShape(String? shape) => (super.noSuchMethod(
         Invocation.method(
-          #setSquareBannerShapeEnabled,
-          [enabled],
+          #setAppBannerShape,
+          [shape],
         ),
         returnValue: _i9.Future<void>.value(),
         returnValueForMissingStub: _i9.Future<void>.value(),


### PR DESCRIPTION
Adds multiple options for the shape of the app banners in the launcher to match the aesthetic of various Smart TV OSes, such as Google TV, Apple TV, Fire OS, Roku, and WebOS. It replaces the previous boolean setting for square app banners.

---
*PR created automatically by Jules for task [8682387635840730809](https://jules.google.com/task/8682387635840730809) started by @LeanBitLab*