### PR TITLE
Refactor "App Banner Shape" to "Themes" with distinct visual styles

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -81,7 +81,7 @@
     "settings": "Settings",
     "show": "Show",
     "showCategoryTitles": "Show category titles",
-    "appBannerShape": "App Banner Shape",
+    "themes": "Themes",
     "hideHighlightOutlineOnHomescreen": "Hide highlight outline on homescreen",
     "appSelectorTransitionAnimation": "App selector transition animation",
     "sort": "Sort",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -80,7 +80,7 @@
     "settings": "Ajustes",
     "show": "Mostrar",
     "showCategoryTitles": "Mostrar títulos de categorías",
-    "appBannerShape": "Forma de los banners de aplicaciones",
+    "themes": "Temas",
     "hideHighlightOutlineOnHomescreen": "Ocultar el contorno de resaltado en la pantalla de inicio",
     "appSelectorTransitionAnimation": "Animación de transición del selector de aplicaciones",
     "sort": "Orden",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -434,11 +434,11 @@ abstract class AppLocalizations {
   /// **'Show category titles'**
   String get showCategoryTitles;
 
-  /// No description provided for @appBannerShape.
+  /// No description provided for @themes.
   ///
   /// In en, this message translates to:
-  /// **'App Banner Shape'**
-  String get appBannerShape;
+  /// **'Themes'**
+  String get themes;
 
   /// No description provided for @hideHighlightOutlineOnHomescreen.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -187,7 +187,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showCategoryTitles => 'Show category titles';
 
   @override
-  String get appBannerShape => 'App Banner Shape';
+  String get themes => 'Themes';
 
   @override
   String get hideHighlightOutlineOnHomescreen =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -190,7 +190,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showCategoryTitles => 'Mostrar títulos de categorías';
 
   @override
-  String get appBannerShape => 'Forma de los banners de aplicaciones';
+  String get themes => 'Temas';
 
   @override
   String get hideHighlightOutlineOnHomescreen =>

--- a/lib/providers/settings_service.dart
+++ b/lib/providers/settings_service.dart
@@ -31,7 +31,7 @@ const _backButtonAction = "back_button_action";
 const _dateFormat = "date_format";
 const _showCategoryTitles = "show_category_titles";
 const _showAppNamesBelowIcons = "show_app_names_below_icons";
-const _appBannerShape = "app_banner_shape";
+const _themes = "app_banner_shape";
 const _hideHighlightOutlineOnHomescreen = "hide_highlight_outline_on_homescreen";
 const _appSelectorTransitionAnimationEnabled = "app_selector_transition_animation_enabled";
 const _showDateInStatusBar = "show_date_in_status_bar";
@@ -81,7 +81,7 @@ class SettingsService extends ChangeNotifier {
 
   bool get showAppNamesBelowIcons => _sharedPreferences.getBool(_showAppNamesBelowIcons) ?? false;
 
-  String get appBannerShape => _sharedPreferences.getString(_appBannerShape) ?? "google_tv";
+  String get themes => _sharedPreferences.getString(_themes) ?? "modern";
 
   bool get hideHighlightOutlineOnHomescreen => _sharedPreferences.getBool(_hideHighlightOutlineOnHomescreen) ?? false;
 
@@ -161,8 +161,8 @@ class SettingsService extends ChangeNotifier {
     return set(_showAppNamesBelowIcons, show);
   }
 
-  Future<void> setAppBannerShape(String shape) async {
-    await _sharedPreferences.setString(_appBannerShape, shape);
+  Future<void> setThemes(String shape) async {
+    await _sharedPreferences.setString(_themes, shape);
     notifyListeners();
   }
 

--- a/lib/widgets/app_card.dart
+++ b/lib/widgets/app_card.dart
@@ -156,28 +156,27 @@ class _AppCardState extends State<AppCard> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final bool showAppNames = context.select<SettingsService, bool>((s) => s.showAppNamesBelowIcons);
-    final String appBannerShape = context.select<SettingsService, String>((s) => s.appBannerShape);
+    final String themes = context.select<SettingsService, String>((s) => s.themes);
     final bool hideHighlightOutlineOnHomescreen = context.select<SettingsService, bool>((s) => s.hideHighlightOutlineOnHomescreen);
     final bool appSelectorTransitionAnimationEnabled = context.select<SettingsService, bool>((s) => s.appSelectorTransitionAnimationEnabled);
 
     BorderRadius borderRadius;
     BorderRadius innerBorderRadius;
 
-    switch (appBannerShape) {
-      case 'apple_tv':
+    switch (themes) {
+      case 'soft':
         borderRadius = BorderRadius.circular(16);
         innerBorderRadius = BorderRadius.circular(14);
         break;
-      case 'roku_os':
-      case 'fire_os':
+      case 'classic':
         borderRadius = BorderRadius.zero;
         innerBorderRadius = BorderRadius.zero;
         break;
-      case 'web_os':
+      case 'pill':
         borderRadius = BorderRadius.circular(100);
         innerBorderRadius = BorderRadius.circular(98);
         break;
-      case 'google_tv':
+      case 'modern':
       default:
         borderRadius = BorderRadius.circular(8);
         innerBorderRadius = BorderRadius.circular(6);
@@ -216,11 +215,11 @@ class _AppCardState extends State<AppCard> with TickerProviderStateMixin {
                         duration: appSelectorTransitionAnimationEnabled ? const Duration(milliseconds: 200) : Duration.zero,
                         curve: Curves.easeInOut,
                         transformAlignment: Alignment.center,
-                        transform: _scaleTransform(context),
+                        transform: _scaleTransform(context, themes),
                         child: Material(
                           borderRadius: borderRadius,
                           clipBehavior: Clip.antiAlias,
-                          elevation: shouldHighlight ? 16 : 0,
+                          elevation: shouldHighlight ? (themes == 'soft' ? 32 : (themes == 'classic' ? 8 : 16)) : 0,
                           shadowColor: Colors.black,
                           child: Stack(
                             fit: StackFit.expand,
@@ -264,6 +263,29 @@ class _AppCardState extends State<AppCard> with TickerProviderStateMixin {
                                   final accentColor = Color(int.parse('FF$accentColorHex', radix: 16));
 
                                   if (shouldHighlight && !hideHighlightOutlineOnHomescreen) {
+                                    if (themes == 'soft') {
+                                      _animation.stop();
+                                      return const SizedBox();
+                                    }
+                                    if (themes == 'classic') {
+                                      _animation.stop();
+                                      return IgnorePointer(
+                                        child: Stack(
+                                          fit: StackFit.expand,
+                                          children: [
+                                            Container(
+                                              decoration: BoxDecoration(
+                                                borderRadius: borderRadius,
+                                                border: Border.all(
+                                                  color: accentColor,
+                                                  width: 4
+                                                ),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      );
+                                    }
                                     if (animationEnabled) {
                                       _animation.repeat(reverse: true);
                                       return AnimatedBuilder(
@@ -463,10 +485,16 @@ class _AppCardState extends State<AppCard> with TickerProviderStateMixin {
     return FocusManager.instance.highlightMode == FocusHighlightMode.traditional && Focus.of(context).hasFocus;
   }
 
-  Matrix4 _scaleTransform(BuildContext context) {
+  Matrix4 _scaleTransform(BuildContext context, String theme) {
     double scale = 1.0;
     if (!_moving && _shouldHighlight(context)) {
-      scale = 1.1;
+      if (theme == 'soft') {
+        scale = 1.15;
+      } else if (theme == 'classic') {
+        scale = 1.0;
+      } else {
+        scale = 1.1;
+      }
     }
     return Matrix4.diagonal3Values(scale, scale, 1.0);
   }

--- a/lib/widgets/settings/interface_settings_page.dart
+++ b/lib/widgets/settings/interface_settings_page.dart
@@ -1,3 +1,5 @@
+import 'package:flauncher/widgets/settings/themes_page.dart';
+import 'package:flauncher/widgets/settings/themes_page.dart';
 /*
  * FLauncher
  * Copyright (C) 2024 LeanBitLab
@@ -64,6 +66,16 @@ class InterfaceSettingsPage extends StatelessWidget {
                   onPressed: () => Navigator.of(context).pushNamed(AccentColorPage.routeName),
                 ),
                 FocusableSettingsTile(
+                FocusableSettingsTile(
+                  leading: const Icon(Icons.crop_square),
+                  title: Text(localizations.themes, style: Theme.of(context).textTheme.bodyMedium),
+                  onPressed: () => Navigator.of(context).pushNamed(ThemesPage.routeName),
+                ),
+                FocusableSettingsTile(
+                  leading: const Icon(Icons.crop_square),
+                  title: Text(localizations.themes, style: Theme.of(context).textTheme.bodyMedium),
+                  onPressed: () => Navigator.of(context).pushNamed(ThemesPage.routeName),
+                ),
                   leading: const Icon(Icons.miscellaneous_services),
                   title: Text("Miscellaneous", style: Theme.of(context).textTheme.bodyMedium),
                   onPressed: () => Navigator.of(context).pushNamed(MiscPanelPage.routeName),

--- a/lib/widgets/settings/misc_panel_page.dart
+++ b/lib/widgets/settings/misc_panel_page.dart
@@ -2,7 +2,6 @@
 import 'package:flauncher/providers/settings_service.dart';
 import 'package:flauncher/widgets/rounded_switch_list_tile.dart';
 import 'package:flauncher/widgets/settings/focusable_settings_tile.dart';
-import 'package:flauncher/widgets/settings/app_banner_shape_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -51,9 +50,6 @@ class MiscPanelPage extends StatelessWidget {
                 secondary: Icon(Icons.subtitles),
               ),
               FocusableSettingsTile(
-                leading: Icon(Icons.crop_square),
-                title: Text(localizations.appBannerShape, style: Theme.of(context).textTheme.bodyMedium),
-                onPressed: () => Navigator.of(context).pushNamed(AppBannerShapePage.routeName),
               ),
               RoundedSwitchListTile(
                 value: settingsService.hideHighlightOutlineOnHomescreen,

--- a/lib/widgets/settings/settings_panel.dart
+++ b/lib/widgets/settings/settings_panel.dart
@@ -34,7 +34,7 @@ import 'package:flauncher/widgets/settings/misc_panel_page.dart';
 import 'package:flauncher/widgets/settings/interface_settings_page.dart';
 import 'package:flauncher/widgets/settings/general_settings_page.dart';
 import 'package:flauncher/widgets/settings/screensaver_clock_style_page.dart';
-import 'package:flauncher/widgets/settings/app_banner_shape_page.dart';
+import 'package:flauncher/widgets/settings/themes_page.dart';
 import 'package:flauncher/models/app.dart';
 import 'package:flutter/material.dart';
 
@@ -101,8 +101,8 @@ class _SettingsPanelState extends State<SettingsPanel> {
                       return _FastPageRoute(builder: (_) => MiscPanelPage());
                     case ScreensaverClockStylePage.routeName:
                       return _FastPageRoute(builder: (_) => const ScreensaverClockStylePage());
-                    case AppBannerShapePage.routeName:
-                      return _FastPageRoute(builder: (_) => const AppBannerShapePage());
+                    case ThemesPage.routeName:
+                      return _FastPageRoute(builder: (_) => const ThemesPage());
                     case AccentColorPage.routeName:
                       return _FastPageRoute(builder: (_) => AccentColorPage());
                     case BrightnessSettingsPage.routeName:

--- a/lib/widgets/settings/themes_page.dart
+++ b/lib/widgets/settings/themes_page.dart
@@ -22,23 +22,23 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../providers/settings_service.dart';
 
-class AppBannerShapePage extends StatelessWidget {
-  static const String routeName = "app_banner_shape_panel";
+class ThemesPage extends StatelessWidget {
+  static const String routeName = "themes_panel";
 
-  const AppBannerShapePage({super.key});
+  const ThemesPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
     return Selector<SettingsService, String>(
-      selector: (_, settingsService) => settingsService.appBannerShape,
+      selector: (_, settingsService) => settingsService.themes,
       builder: (context, currentShape, _) {
         final settingsService = context.read<SettingsService>();
 
         return Column(
           children: [
-            Text(localizations.appBannerShape, style: Theme.of(context).textTheme.titleLarge),
+            Text(localizations.themes, style: Theme.of(context).textTheme.titleLarge),
             const Divider(),
             Expanded(
               child: SingleChildScrollView(

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -1308,11 +1308,11 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as bool);
 
   @override
-  String get appBannerShape => (super.noSuchMethod(
-        Invocation.getter(#appBannerShape),
+  String get themes => (super.noSuchMethod(
+        Invocation.getter(#themes),
         returnValue: _i18.dummyValue<String>(
           this,
-          Invocation.getter(#appBannerShape),
+          Invocation.getter(#themes),
         ),
       ) as String);
 
@@ -1533,9 +1533,9 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as _i9.Future<void>);
 
   @override
-  _i9.Future<void> setAppBannerShape(String? shape) => (super.noSuchMethod(
+  _i9.Future<void> setThemes(String? shape) => (super.noSuchMethod(
         Invocation.method(
-          #setAppBannerShape,
+          #setThemes,
           [shape],
         ),
         returnValue: _i9.Future<void>.value(),


### PR DESCRIPTION
- Renamed "App Banner Shape" settings to "Themes"
- Moved "Themes" option from the "Miscellaneous" settings page to the "Interface" settings page
- Redesigned and renamed the theme options to be unique (Modern, Soft, Classic, Pill)
- Updated AppCard to render distinct visual styles for each theme (e.g. distinct borders, drop shadows, and scale factors on focus)

---
*PR created automatically by Jules for task [6628885725418631225](https://jules.google.com/task/6628885725418631225) started by @LeanBitLab*