### PR TITLE
Generalize WiFi usage to track total data usage

### DIFF
--- a/android/app/src/main/java/com/leanbitlab/ltvL/MainActivity.java
+++ b/android/app/src/main/java/com/leanbitlab/ltvL/MainActivity.java
@@ -89,24 +89,24 @@ public class MainActivity extends FlutterActivity {
                 case "checkForGetContentAvailability" -> result.success(checkForGetContentAvailability());
                 case "startAmbientMode" -> result.success(startAmbientMode());
                 case "getActiveNetworkInformation" -> result.success(getActiveNetworkInformation());
-                case "getDailyWifiUsage" -> {
-                    long usage = getDailyWifiUsage();
+                case "getDailyDataUsage" -> {
+                    long usage = getDailyDataUsage();
                     if (usage == -1) {
                         result.error("PERMISSION_DENIED", "Usage stats permission not granted", null);
                     } else {
                         result.success(usage);
                     }
                 }
-                case "getWeeklyWifiUsage" -> {
-                    long usage = getWeeklyWifiUsage();
+                case "getWeeklyDataUsage" -> {
+                    long usage = getWeeklyDataUsage();
                     if (usage == -1) {
                         result.error("PERMISSION_DENIED", "Usage stats permission not granted", null);
                     } else {
                         result.success(usage);
                     }
                 }
-                case "getMonthlyWifiUsage" -> {
-                    long usage = getMonthlyWifiUsage();
+                case "getMonthlyDataUsage" -> {
+                    long usage = getMonthlyDataUsage();
                     if (usage == -1) {
                         result.error("PERMISSION_DENIED", "Usage stats permission not granted", null);
                     } else {
@@ -434,7 +434,7 @@ public class MainActivity extends FlutterActivity {
         return bitmap;
     }
 
-    private long getDailyWifiUsage() {
+    private long getDailyDataUsage() {
         if (!checkUsageStatsPermission()) {
             return -1;
         }
@@ -453,20 +453,42 @@ public class MainActivity extends FlutterActivity {
 
         long totalBytes = 0;
         try {
-            NetworkStats.Bucket bucket = networkStatsManager.querySummaryForDevice(
-                    NetworkCapabilities.TRANSPORT_WIFI,
-                    "",
+            NetworkStats.Bucket wifiBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_WIFI,
+                    null,
                     startTime,
                     endTime);
-            totalBytes = bucket.getRxBytes() + bucket.getTxBytes();
-        } catch (RemoteException e) {
+            totalBytes += wifiBucket.getRxBytes() + wifiBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket mobileBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_MOBILE,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += mobileBucket.getRxBytes() + mobileBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket ethernetBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_ETHERNET,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += ethernetBucket.getRxBytes() + ethernetBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
             e.printStackTrace();
         }
 
         return totalBytes;
     }
 
-    private long getWeeklyWifiUsage() {
+    private long getWeeklyDataUsage() {
         if (!checkUsageStatsPermission()) {
             return -1;
         }
@@ -486,20 +508,42 @@ public class MainActivity extends FlutterActivity {
 
         long totalBytes = 0;
         try {
-            NetworkStats.Bucket bucket = networkStatsManager.querySummaryForDevice(
-                    NetworkCapabilities.TRANSPORT_WIFI,
-                    "",
+            NetworkStats.Bucket wifiBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_WIFI,
+                    null,
                     startTime,
                     endTime);
-            totalBytes = bucket.getRxBytes() + bucket.getTxBytes();
-        } catch (RemoteException e) {
+            totalBytes += wifiBucket.getRxBytes() + wifiBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket mobileBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_MOBILE,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += mobileBucket.getRxBytes() + mobileBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket ethernetBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_ETHERNET,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += ethernetBucket.getRxBytes() + ethernetBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
             e.printStackTrace();
         }
 
         return totalBytes;
     }
 
-    private long getMonthlyWifiUsage() {
+    private long getMonthlyDataUsage() {
         if (!checkUsageStatsPermission()) {
             return -1;
         }
@@ -519,13 +563,35 @@ public class MainActivity extends FlutterActivity {
 
         long totalBytes = 0;
         try {
-            NetworkStats.Bucket bucket = networkStatsManager.querySummaryForDevice(
-                    NetworkCapabilities.TRANSPORT_WIFI,
-                    "",
+            NetworkStats.Bucket wifiBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_WIFI,
+                    null,
                     startTime,
                     endTime);
-            totalBytes = bucket.getRxBytes() + bucket.getTxBytes();
-        } catch (RemoteException e) {
+            totalBytes += wifiBucket.getRxBytes() + wifiBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket mobileBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_MOBILE,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += mobileBucket.getRxBytes() + mobileBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket ethernetBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_ETHERNET,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += ethernetBucket.getRxBytes() + ethernetBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
             e.printStackTrace();
         }
 

--- a/android/app/src/main/java/me/efesser/flauncher/MainActivity.java
+++ b/android/app/src/main/java/me/efesser/flauncher/MainActivity.java
@@ -89,24 +89,24 @@ public class MainActivity extends FlutterActivity {
                 case "checkForGetContentAvailability" -> result.success(checkForGetContentAvailability());
                 case "startAmbientMode" -> result.success(startAmbientMode());
                 case "getActiveNetworkInformation" -> result.success(getActiveNetworkInformation());
-                case "getDailyWifiUsage" -> {
-                    long usage = getDailyWifiUsage();
+                case "getDailyDataUsage" -> {
+                    long usage = getDailyDataUsage();
                     if (usage == -1) {
                         result.error("PERMISSION_DENIED", "Usage stats permission not granted", null);
                     } else {
                         result.success(usage);
                     }
                 }
-                case "getWeeklyWifiUsage" -> {
-                    long usage = getWeeklyWifiUsage();
+                case "getWeeklyDataUsage" -> {
+                    long usage = getWeeklyDataUsage();
                     if (usage == -1) {
                         result.error("PERMISSION_DENIED", "Usage stats permission not granted", null);
                     } else {
                         result.success(usage);
                     }
                 }
-                case "getMonthlyWifiUsage" -> {
-                    long usage = getMonthlyWifiUsage();
+                case "getMonthlyDataUsage" -> {
+                    long usage = getMonthlyDataUsage();
                     if (usage == -1) {
                         result.error("PERMISSION_DENIED", "Usage stats permission not granted", null);
                     } else {
@@ -425,7 +425,7 @@ public class MainActivity extends FlutterActivity {
         return bitmap;
     }
 
-    private long getDailyWifiUsage() {
+    private long getDailyDataUsage() {
         if (!checkUsageStatsPermission()) {
             return -1;
         }
@@ -444,20 +444,42 @@ public class MainActivity extends FlutterActivity {
 
         long totalBytes = 0;
         try {
-            NetworkStats.Bucket bucket = networkStatsManager.querySummaryForDevice(
-                    NetworkCapabilities.TRANSPORT_WIFI,
-                    "",
+            NetworkStats.Bucket wifiBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_WIFI,
+                    null,
                     startTime,
                     endTime);
-            totalBytes = bucket.getRxBytes() + bucket.getTxBytes();
-        } catch (RemoteException e) {
+            totalBytes += wifiBucket.getRxBytes() + wifiBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket mobileBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_MOBILE,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += mobileBucket.getRxBytes() + mobileBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket ethernetBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_ETHERNET,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += ethernetBucket.getRxBytes() + ethernetBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
             e.printStackTrace();
         }
 
         return totalBytes;
     }
 
-    private long getWeeklyWifiUsage() {
+    private long getWeeklyDataUsage() {
         if (!checkUsageStatsPermission()) {
             return -1;
         }
@@ -477,20 +499,42 @@ public class MainActivity extends FlutterActivity {
 
         long totalBytes = 0;
         try {
-            NetworkStats.Bucket bucket = networkStatsManager.querySummaryForDevice(
-                    NetworkCapabilities.TRANSPORT_WIFI,
-                    "",
+            NetworkStats.Bucket wifiBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_WIFI,
+                    null,
                     startTime,
                     endTime);
-            totalBytes = bucket.getRxBytes() + bucket.getTxBytes();
-        } catch (RemoteException e) {
+            totalBytes += wifiBucket.getRxBytes() + wifiBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket mobileBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_MOBILE,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += mobileBucket.getRxBytes() + mobileBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket ethernetBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_ETHERNET,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += ethernetBucket.getRxBytes() + ethernetBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
             e.printStackTrace();
         }
 
         return totalBytes;
     }
 
-    private long getMonthlyWifiUsage() {
+    private long getMonthlyDataUsage() {
         if (!checkUsageStatsPermission()) {
             return -1;
         }
@@ -510,13 +554,35 @@ public class MainActivity extends FlutterActivity {
 
         long totalBytes = 0;
         try {
-            NetworkStats.Bucket bucket = networkStatsManager.querySummaryForDevice(
-                    NetworkCapabilities.TRANSPORT_WIFI,
-                    "",
+            NetworkStats.Bucket wifiBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_WIFI,
+                    null,
                     startTime,
                     endTime);
-            totalBytes = bucket.getRxBytes() + bucket.getTxBytes();
-        } catch (RemoteException e) {
+            totalBytes += wifiBucket.getRxBytes() + wifiBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket mobileBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_MOBILE,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += mobileBucket.getRxBytes() + mobileBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            NetworkStats.Bucket ethernetBucket = networkStatsManager.querySummaryForDevice(
+                    ConnectivityManager.TYPE_ETHERNET,
+                    null,
+                    startTime,
+                    endTime);
+            totalBytes += ethernetBucket.getRxBytes() + ethernetBucket.getTxBytes();
+        } catch (RemoteException | SecurityException e) {
             e.printStackTrace();
         }
 

--- a/lib/flauncher_channel.dart
+++ b/lib/flauncher_channel.dart
@@ -60,27 +60,27 @@ class FLauncherChannel {
     return map.cast<String, dynamic>();
   }
 
-  Future<int> getDailyWifiUsage() async {
+  Future<int> getDailyDataUsage() async {
     try {
-      final int usage = await _methodChannel.invokeMethod("getDailyWifiUsage");
+      final int usage = await _methodChannel.invokeMethod("getDailyDataUsage");
       return usage;
     } on PlatformException catch (_) {
       return -1;
     }
   }
 
-  Future<int> getWeeklyWifiUsage() async {
+  Future<int> getWeeklyDataUsage() async {
     try {
-      final int usage = await _methodChannel.invokeMethod("getWeeklyWifiUsage");
+      final int usage = await _methodChannel.invokeMethod("getWeeklyDataUsage");
       return usage;
     } on PlatformException catch (_) {
       return -1;
     }
   }
 
-  Future<int> getMonthlyWifiUsage() async {
+  Future<int> getMonthlyDataUsage() async {
     try {
-      final int usage = await _methodChannel.invokeMethod("getMonthlyWifiUsage");
+      final int usage = await _methodChannel.invokeMethod("getMonthlyDataUsage");
       return usage;
     } on PlatformException catch (_) {
       return -1;

--- a/lib/providers/network_service.dart
+++ b/lib/providers/network_service.dart
@@ -63,7 +63,7 @@ class NetworkService extends ChangeNotifier
   CellularNetworkType _cellularNetworkType;
   NetworkType         _networkType;
   int                 _wirelessNetworkSignalLevel;
-  int                 _dailyWifiUsage; // In bytes
+  int                 _dailyDataUsage; // In bytes
   bool                _hasUsageStatsPermission;
   Timer?              _usageTimer;
 
@@ -73,7 +73,7 @@ class NetworkService extends ChangeNotifier
         _cellularNetworkType = CellularNetworkType.Unknown,
         _networkType = NetworkType.Unknown,
         _wirelessNetworkSignalLevel = 0,
-        _dailyWifiUsage = 0,
+        _dailyDataUsage = 0,
         _hasUsageStatsPermission = false
   {
     _channel.addNetworkChangedListener(_onNetworkChanged);
@@ -126,23 +126,23 @@ class NetworkService extends ChangeNotifier
   Future<void> _fetchUsage() async {
      // This will be called with the current period from the widget
      // For now, default to daily
-     int usage = await _channel.getDailyWifiUsage();
+     int usage = await _channel.getDailyDataUsage();
      if (usage != -1) {
-       _dailyWifiUsage = usage;
+       _dailyDataUsage = usage;
        notifyListeners();
      }
   }
 
-  Future<int> getWifiUsageForPeriod(String period) async {
+  Future<int> getDataUsageForPeriod(String period) async {
     switch (period) {
       case 'daily':
-        return await _channel.getDailyWifiUsage();
+        return await _channel.getDailyDataUsage();
       case 'weekly':
-        return await _channel.getWeeklyWifiUsage();
+        return await _channel.getWeeklyDataUsage();
       case 'monthly':
-        return await _channel.getMonthlyWifiUsage();
+        return await _channel.getMonthlyDataUsage();
       default:
-        return await _channel.getDailyWifiUsage();
+        return await _channel.getDailyDataUsage();
     }
   }
 
@@ -156,7 +156,7 @@ class NetworkService extends ChangeNotifier
   CellularNetworkType   get   cellularNetworkType           => _cellularNetworkType;
   NetworkType           get   networkType                   => _networkType;
   int                   get   wirelessNetworkSignalLevel    => _wirelessNetworkSignalLevel;
-  int                 get   dailyWifiUsage                => _dailyWifiUsage;
+  int                 get   dailyDataUsage                => _dailyDataUsage;
   bool                get   hasUsageStatsPermission       => _hasUsageStatsPermission;
 
   CellularNetworkType _getCellularNetworkType(int index)

--- a/lib/providers/settings_service.dart
+++ b/lib/providers/settings_service.dart
@@ -37,16 +37,16 @@ const _appSelectorTransitionAnimationEnabled = "app_selector_transition_animatio
 const _showDateInStatusBar = "show_date_in_status_bar";
 const _showTimeInStatusBar = "show_time_in_status_bar";
 const _timeFormat = "time_format";
-const _wifiUsagePeriod = "wifi_usage_period";
-const _showWifiWidgetInStatusBar = "show_wifi_widget_in_status_bar";
+const _dataUsagePeriod = "wifi_usage_period";
+const _showDataWidgetInStatusBar = "show_wifi_widget_in_status_bar";
 const String _showNetworkIndicatorInStatusBar = "show_network_indicator_in_status_bar";
 const String _accentColor = "accent_color";
 const String _screensaverClockStyle = "screensaver_clock_style";
 
 // WiFi usage period options
-const String WIFI_USAGE_DAILY = "daily";
-const String WIFI_USAGE_WEEKLY = "weekly";
-const String WIFI_USAGE_MONTHLY = "monthly";
+const String DATA_USAGE_DAILY = "daily";
+const String DATA_USAGE_WEEKLY = "weekly";
+const String DATA_USAGE_MONTHLY = "monthly";
 
 // Accent color presets (hex values)
 const String ACCENT_COLOR_PURPLE = "7C4DFF";
@@ -99,9 +99,9 @@ class SettingsService extends ChangeNotifier {
 
   String get timeFormat => _sharedPreferences.getString(_timeFormat) ?? defaultTimeFormat;
 
-  String get wifiUsagePeriod => _sharedPreferences.getString(_wifiUsagePeriod) ?? WIFI_USAGE_DAILY;
+  String get dataUsagePeriod => _sharedPreferences.getString(_dataUsagePeriod) ?? DATA_USAGE_DAILY;
 
-  bool get showWifiWidgetInStatusBar => _sharedPreferences.getBool(_showWifiWidgetInStatusBar) ?? true;
+  bool get showDataWidgetInStatusBar => _sharedPreferences.getBool(_showDataWidgetInStatusBar) ?? true;
 
   bool get showNetworkIndicatorInStatusBar => _sharedPreferences.getBool(_showNetworkIndicatorInStatusBar) ?? true;
 
@@ -182,13 +182,13 @@ class SettingsService extends ChangeNotifier {
     return set(_showTimeInStatusBar, show);
   }
 
-  Future<void> setWifiUsagePeriod(String period) async {
-    await _sharedPreferences.setString(_wifiUsagePeriod, period);
+  Future<void> setDataUsagePeriod(String period) async {
+    await _sharedPreferences.setString(_dataUsagePeriod, period);
     notifyListeners();
   }
 
-  Future<void> setShowWifiWidgetInStatusBar(bool show) async {
-    return set(_showWifiWidgetInStatusBar, show);
+  Future<void> setShowDataWidgetInStatusBar(bool show) async {
+    return set(_showDataWidgetInStatusBar, show);
   }
 
   Future<void> setShowNetworkIndicatorInStatusBar(bool show) async {

--- a/lib/widgets/daily_data_usage_widget.dart
+++ b/lib/widgets/daily_data_usage_widget.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
-class DailyWifiUsageWidget extends StatelessWidget {
-  const DailyWifiUsageWidget({super.key});
+class DailyDataUsageWidget extends StatelessWidget {
+  const DailyDataUsageWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +19,7 @@ class DailyWifiUsageWidget extends StatelessWidget {
           );
         }
 
-        final period = settingsService.wifiUsagePeriod;
+        final period = settingsService.dataUsagePeriod;
         String label;
         switch (period) {
           case 'weekly':
@@ -35,9 +35,9 @@ class DailyWifiUsageWidget extends StatelessWidget {
         }
 
         return FutureBuilder<int>(
-          future: networkService.getWifiUsageForPeriod(period),
+          future: networkService.getDataUsageForPeriod(period),
           builder: (context, snapshot) {
-            final usage = snapshot.data ?? networkService.dailyWifiUsage;
+            final usage = snapshot.data ?? networkService.dailyDataUsage;
             final usageString = _formatBytes(usage);
 
             return RichText(

--- a/lib/widgets/focus_aware_app_bar.dart
+++ b/lib/widgets/focus_aware_app_bar.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../providers/settings_service.dart';
-import 'daily_wifi_usage_widget.dart';
+import 'daily_data_usage_widget.dart';
 import 'date_time_widget.dart';
 import 'network_widget.dart';
 
@@ -91,11 +91,11 @@ class FocusAwareAppBarState extends State<FocusAwareAppBar>
                     )
                   : const SizedBox.shrink(),
               ),
-              // WiFi usage widget
+              // Data usage widget
               Selector<SettingsService, bool>(
-                selector: (_, settings) => settings.showWifiWidgetInStatusBar,
-                builder: (context, showWifi, _) => showWifi
-                  ? const DailyWifiUsageWidget()
+                selector: (_, settings) => settings.showDataWidgetInStatusBar,
+                builder: (context, showData, _) => showData
+                  ? const DailyDataUsageWidget()
                   : const SizedBox.shrink(),
               ),
             ],

--- a/lib/widgets/settings/data_usage_period_page.dart
+++ b/lib/widgets/settings/data_usage_period_page.dart
@@ -4,10 +4,10 @@ import 'package:flauncher/widgets/settings/focusable_settings_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class WifiUsagePeriodPage extends StatelessWidget {
-  static const String routeName = "wifi_usage_period_panel";
+class DataUsagePeriodPage extends StatelessWidget {
+  static const String routeName = "data_usage_period_panel";
 
-  const WifiUsagePeriodPage({Key? key}) : super(key: key);
+  const DataUsagePeriodPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -15,14 +15,14 @@ class WifiUsagePeriodPage extends StatelessWidget {
         builder: (context, service, _) {
           return Column(
             children: [
-              Text('WiFi Usage Period', style: Theme.of(context).textTheme.titleLarge),
+              Text('Data Usage Period', style: Theme.of(context).textTheme.titleLarge),
               const Divider(),
               Expanded(
                 child: ListView(
                   children: [
-                    _radioTile(context, service, 'Daily', WIFI_USAGE_DAILY),
-                    _radioTile(context, service, 'Weekly', WIFI_USAGE_WEEKLY),
-                    _radioTile(context, service, 'Monthly', WIFI_USAGE_MONTHLY),
+                    _radioTile(context, service, 'Daily', DATA_USAGE_DAILY),
+                    _radioTile(context, service, 'Weekly', DATA_USAGE_WEEKLY),
+                    _radioTile(context, service, 'Monthly', DATA_USAGE_MONTHLY),
                   ],
                 ),
               ),
@@ -33,14 +33,14 @@ class WifiUsagePeriodPage extends StatelessWidget {
   }
 
   Widget _radioTile(BuildContext context, SettingsService service, String label, String value) {
-    final isSelected = service.wifiUsagePeriod == value;
+    final isSelected = service.dataUsagePeriod == value;
     return FocusableSettingsTile(
       leading: Icon(
         isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
         color: isSelected ? Theme.of(context).colorScheme.secondary : Colors.grey,
       ),
       title: Text(label, style: Theme.of(context).textTheme.bodyMedium),
-      onPressed: () => service.setWifiUsagePeriod(value),
+      onPressed: () => service.setDataUsagePeriod(value),
     );
   }
 }

--- a/lib/widgets/settings/general_settings_page.dart
+++ b/lib/widgets/settings/general_settings_page.dart
@@ -23,7 +23,7 @@ import 'focusable_settings_tile.dart';
 import 'brightness_settings_page.dart';
 import 'date_time_format_page.dart';
 import 'back_button_action_page.dart';
-import 'wifi_usage_period_page.dart';
+import 'data_usage_period_page.dart';
 import 'screensaver_clock_style_page.dart';
 
 
@@ -71,9 +71,9 @@ class GeneralSettingsPage extends StatelessWidget {
                   onPressed: () => Navigator.of(context).pushNamed(BackButtonActionPage.routeName),
                 ),
                 FocusableSettingsTile(
-                  leading: const Icon(Icons.wifi),
-                  title: Text('WiFi Usage Period', style: Theme.of(context).textTheme.bodyMedium),
-                  onPressed: () => Navigator.of(context).pushNamed(WifiUsagePeriodPage.routeName),
+                  leading: const Icon(Icons.data_usage),
+                  title: Text('Data Usage Period', style: Theme.of(context).textTheme.bodyMedium),
+                  onPressed: () => Navigator.of(context).pushNamed(DataUsagePeriodPage.routeName),
                 ),
 
               ],

--- a/lib/widgets/settings/settings_panel.dart
+++ b/lib/widgets/settings/settings_panel.dart
@@ -24,7 +24,7 @@ import 'package:flauncher/widgets/settings/launcher_section_panel_page.dart';
 import 'package:flauncher/widgets/settings/settings_panel_page.dart';
 import 'package:flauncher/widgets/settings/status_bar_panel_page.dart';
 import 'package:flauncher/widgets/settings/wallpaper_panel_page.dart';
-import 'package:flauncher/widgets/settings/wifi_usage_period_page.dart';
+import 'package:flauncher/widgets/settings/data_usage_period_page.dart';
 import 'package:flauncher/widgets/settings/back_button_action_page.dart';
 import 'package:flauncher/widgets/settings/date_time_format_page.dart';
 import 'package:flauncher/widgets/settings/app_details_page.dart';
@@ -91,8 +91,8 @@ class _SettingsPanelState extends State<SettingsPanel> {
                     case LauncherSectionPanelPage.routeName:
                       return _FastPageRoute(
                           builder: (_) => LauncherSectionPanelPage(sectionIndex: settings.arguments as int?));
-                    case WifiUsagePeriodPage.routeName:
-                      return _FastPageRoute(builder: (_) => WifiUsagePeriodPage());
+                    case DataUsagePeriodPage.routeName:
+                      return _FastPageRoute(builder: (_) => DataUsagePeriodPage());
                     case BackButtonActionPage.routeName:
                       return _FastPageRoute(builder: (_) => BackButtonActionPage());
                     case DateTimeFormatPage.routeName:

--- a/lib/widgets/settings/status_bar_panel_page.dart
+++ b/lib/widgets/settings/status_bar_panel_page.dart
@@ -60,10 +60,10 @@ class StatusBarPanelPage extends StatelessWidget {
                   secondary: Icon(Icons.watch_later_outlined)
                 ),
                 RoundedSwitchListTile(
-                  value: settingsService.showWifiWidgetInStatusBar,
-                  onChanged: (value) => settingsService.setShowWifiWidgetInStatusBar(value),
-                  title: Text('WiFi Usage'),
-                  secondary: Icon(Icons.wifi)
+                  value: settingsService.showDataWidgetInStatusBar,
+                  onChanged: (value) => settingsService.setShowDataWidgetInStatusBar(value),
+                  title: Text('Data Usage'),
+                  secondary: Icon(Icons.data_usage)
                 ),
                 RoundedSwitchListTile(
                   value: settingsService.showNetworkIndicatorInStatusBar,

--- a/test/flauncher_channel_test.dart
+++ b/test/flauncher_channel_test.dart
@@ -159,92 +159,92 @@ void main() {
     expect(called, isTrue);
   });
 
-  test("getDailyWifiUsage success", () async {
+  test("getDailyDataUsage success", () async {
     final channel = MethodChannel('me.efesser.flauncher/method');
     channel.setMockMethodCallHandler((call) async {
-      if (call.method == "getDailyWifiUsage") {
+      if (call.method == "getDailyDataUsage") {
         return 12345;
       }
       fail("Unhandled method name");
     });
     final fLauncherChannel = FLauncherChannel();
 
-    final usage = await fLauncherChannel.getDailyWifiUsage();
+    final usage = await fLauncherChannel.getDailyDataUsage();
 
     expect(usage, 12345);
   });
 
-  test("getDailyWifiUsage platform exception", () async {
+  test("getDailyDataUsage platform exception", () async {
     final channel = MethodChannel('me.efesser.flauncher/method');
     channel.setMockMethodCallHandler((call) async {
-      if (call.method == "getDailyWifiUsage") {
+      if (call.method == "getDailyDataUsage") {
         throw PlatformException(code: "ERROR");
       }
       fail("Unhandled method name");
     });
     final fLauncherChannel = FLauncherChannel();
 
-    final usage = await fLauncherChannel.getDailyWifiUsage();
+    final usage = await fLauncherChannel.getDailyDataUsage();
 
     expect(usage, -1);
   });
 
-  test("getWeeklyWifiUsage success", () async {
+  test("getWeeklyDataUsage success", () async {
     final channel = MethodChannel('me.efesser.flauncher/method');
     channel.setMockMethodCallHandler((call) async {
-      if (call.method == "getWeeklyWifiUsage") {
+      if (call.method == "getWeeklyDataUsage") {
         return 67890;
       }
       fail("Unhandled method name");
     });
     final fLauncherChannel = FLauncherChannel();
 
-    final usage = await fLauncherChannel.getWeeklyWifiUsage();
+    final usage = await fLauncherChannel.getWeeklyDataUsage();
 
     expect(usage, 67890);
   });
 
-  test("getWeeklyWifiUsage platform exception", () async {
+  test("getWeeklyDataUsage platform exception", () async {
     final channel = MethodChannel('me.efesser.flauncher/method');
     channel.setMockMethodCallHandler((call) async {
-      if (call.method == "getWeeklyWifiUsage") {
+      if (call.method == "getWeeklyDataUsage") {
         throw PlatformException(code: "ERROR");
       }
       fail("Unhandled method name");
     });
     final fLauncherChannel = FLauncherChannel();
 
-    final usage = await fLauncherChannel.getWeeklyWifiUsage();
+    final usage = await fLauncherChannel.getWeeklyDataUsage();
 
     expect(usage, -1);
   });
 
-  test("getMonthlyWifiUsage success", () async {
+  test("getMonthlyDataUsage success", () async {
     final channel = MethodChannel('me.efesser.flauncher/method');
     channel.setMockMethodCallHandler((call) async {
-      if (call.method == "getMonthlyWifiUsage") {
+      if (call.method == "getMonthlyDataUsage") {
         return 99999;
       }
       fail("Unhandled method name");
     });
     final fLauncherChannel = FLauncherChannel();
 
-    final usage = await fLauncherChannel.getMonthlyWifiUsage();
+    final usage = await fLauncherChannel.getMonthlyDataUsage();
 
     expect(usage, 99999);
   });
 
-  test("getMonthlyWifiUsage platform exception", () async {
+  test("getMonthlyDataUsage platform exception", () async {
     final channel = MethodChannel('me.efesser.flauncher/method');
     channel.setMockMethodCallHandler((call) async {
-      if (call.method == "getMonthlyWifiUsage") {
+      if (call.method == "getMonthlyDataUsage") {
         throw PlatformException(code: "ERROR");
       }
       fail("Unhandled method name");
     });
     final fLauncherChannel = FLauncherChannel();
 
-    final usage = await fLauncherChannel.getMonthlyWifiUsage();
+    final usage = await fLauncherChannel.getMonthlyDataUsage();
 
     expect(usage, -1);
   });

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -466,27 +466,27 @@ class MockFLauncherChannel extends _i1.Mock implements _i12.FLauncherChannel {
       ) as _i9.Future<Map<String, dynamic>>);
 
   @override
-  _i9.Future<int> getDailyWifiUsage() => (super.noSuchMethod(
+  _i9.Future<int> getDailyDataUsage() => (super.noSuchMethod(
         Invocation.method(
-          #getDailyWifiUsage,
+          #getDailyDataUsage,
           [],
         ),
         returnValue: _i9.Future<int>.value(0),
       ) as _i9.Future<int>);
 
   @override
-  _i9.Future<int> getWeeklyWifiUsage() => (super.noSuchMethod(
+  _i9.Future<int> getWeeklyDataUsage() => (super.noSuchMethod(
         Invocation.method(
-          #getWeeklyWifiUsage,
+          #getWeeklyDataUsage,
           [],
         ),
         returnValue: _i9.Future<int>.value(0),
       ) as _i9.Future<int>);
 
   @override
-  _i9.Future<int> getMonthlyWifiUsage() => (super.noSuchMethod(
+  _i9.Future<int> getMonthlyDataUsage() => (super.noSuchMethod(
         Invocation.method(
-          #getMonthlyWifiUsage,
+          #getMonthlyDataUsage,
           [],
         ),
         returnValue: _i9.Future<int>.value(0),
@@ -1368,17 +1368,17 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as String);
 
   @override
-  String get wifiUsagePeriod => (super.noSuchMethod(
-        Invocation.getter(#wifiUsagePeriod),
+  String get dataUsagePeriod => (super.noSuchMethod(
+        Invocation.getter(#dataUsagePeriod),
         returnValue: _i18.dummyValue<String>(
           this,
-          Invocation.getter(#wifiUsagePeriod),
+          Invocation.getter(#dataUsagePeriod),
         ),
       ) as String);
 
   @override
-  bool get showWifiWidgetInStatusBar => (super.noSuchMethod(
-        Invocation.getter(#showWifiWidgetInStatusBar),
+  bool get showDataWidgetInStatusBar => (super.noSuchMethod(
+        Invocation.getter(#showDataWidgetInStatusBar),
         returnValue: false,
       ) as bool);
 
@@ -1585,9 +1585,9 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as _i9.Future<void>);
 
   @override
-  _i9.Future<void> setWifiUsagePeriod(String? period) => (super.noSuchMethod(
+  _i9.Future<void> setDataUsagePeriod(String? period) => (super.noSuchMethod(
         Invocation.method(
-          #setWifiUsagePeriod,
+          #setDataUsagePeriod,
           [period],
         ),
         returnValue: _i9.Future<void>.value(),
@@ -1595,10 +1595,10 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
       ) as _i9.Future<void>);
 
   @override
-  _i9.Future<void> setShowWifiWidgetInStatusBar(bool? show) =>
+  _i9.Future<void> setShowDataWidgetInStatusBar(bool? show) =>
       (super.noSuchMethod(
         Invocation.method(
-          #setShowWifiWidgetInStatusBar,
+          #setShowDataWidgetInStatusBar,
           [show],
         ),
         returnValue: _i9.Future<void>.value(),

--- a/test/providers/network_service_test.dart
+++ b/test/providers/network_service_test.dart
@@ -24,49 +24,49 @@ void main() {
     networkService.dispose();
   });
 
-  group('getWifiUsageForPeriod', () {
+  group('getDataUsageForPeriod', () {
     test('returns daily usage when period is "daily"', () async {
-      when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+      when(mockChannel.getDailyDataUsage()).thenAnswer((_) async => 100);
 
-      final result = await networkService.getWifiUsageForPeriod('daily');
+      final result = await networkService.getDataUsageForPeriod('daily');
 
       expect(result, 100);
-      verify(mockChannel.getDailyWifiUsage()).called(1);
-      verifyNever(mockChannel.getWeeklyWifiUsage());
-      verifyNever(mockChannel.getMonthlyWifiUsage());
+      verify(mockChannel.getDailyDataUsage()).called(1);
+      verifyNever(mockChannel.getWeeklyDataUsage());
+      verifyNever(mockChannel.getMonthlyDataUsage());
     });
 
     test('returns weekly usage when period is "weekly"', () async {
-      when(mockChannel.getWeeklyWifiUsage()).thenAnswer((_) async => 500);
+      when(mockChannel.getWeeklyDataUsage()).thenAnswer((_) async => 500);
 
-      final result = await networkService.getWifiUsageForPeriod('weekly');
+      final result = await networkService.getDataUsageForPeriod('weekly');
 
       expect(result, 500);
-      verify(mockChannel.getWeeklyWifiUsage()).called(1);
-      verifyNever(mockChannel.getDailyWifiUsage());
-      verifyNever(mockChannel.getMonthlyWifiUsage());
+      verify(mockChannel.getWeeklyDataUsage()).called(1);
+      verifyNever(mockChannel.getDailyDataUsage());
+      verifyNever(mockChannel.getMonthlyDataUsage());
     });
 
     test('returns monthly usage when period is "monthly"', () async {
-      when(mockChannel.getMonthlyWifiUsage()).thenAnswer((_) async => 2000);
+      when(mockChannel.getMonthlyDataUsage()).thenAnswer((_) async => 2000);
 
-      final result = await networkService.getWifiUsageForPeriod('monthly');
+      final result = await networkService.getDataUsageForPeriod('monthly');
 
       expect(result, 2000);
-      verify(mockChannel.getMonthlyWifiUsage()).called(1);
-      verifyNever(mockChannel.getDailyWifiUsage());
-      verifyNever(mockChannel.getWeeklyWifiUsage());
+      verify(mockChannel.getMonthlyDataUsage()).called(1);
+      verifyNever(mockChannel.getDailyDataUsage());
+      verifyNever(mockChannel.getWeeklyDataUsage());
     });
 
     test('returns daily usage when period is unknown', () async {
-      when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+      when(mockChannel.getDailyDataUsage()).thenAnswer((_) async => 100);
 
-      final result = await networkService.getWifiUsageForPeriod('unknown_period');
+      final result = await networkService.getDataUsageForPeriod('unknown_period');
 
       expect(result, 100);
-      verify(mockChannel.getDailyWifiUsage()).called(1);
-      verifyNever(mockChannel.getWeeklyWifiUsage());
-      verifyNever(mockChannel.getMonthlyWifiUsage());
+      verify(mockChannel.getDailyDataUsage()).called(1);
+      verifyNever(mockChannel.getWeeklyDataUsage());
+      verifyNever(mockChannel.getMonthlyDataUsage());
     });
   });
 
@@ -74,7 +74,7 @@ void main() {
     test('when permission granted, fetches usage and notifies listeners periodically', () {
       fakeAsync((async) {
         when(mockChannel.checkUsageStatsPermission()).thenAnswer((_) async => true);
-        when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+        when(mockChannel.getDailyDataUsage()).thenAnswer((_) async => 100);
 
         int listenerCallCount = 0;
         networkService.addListener(() {
@@ -87,15 +87,15 @@ void main() {
         async.flushMicrotasks();
 
         expect(networkService.hasUsageStatsPermission, isTrue);
-        expect(networkService.dailyWifiUsage, 100);
+        expect(networkService.dailyDataUsage, 100);
         expect(listenerCallCount, greaterThanOrEqualTo(2));
-        verify(mockChannel.getDailyWifiUsage()).called(1);
+        verify(mockChannel.getDailyDataUsage()).called(1);
 
         // advance 5 minutes
         async.elapse(const Duration(minutes: 5));
 
         // Timer should have fired, calling _fetchUsage again
-        verify(mockChannel.getDailyWifiUsage()).called(1);
+        verify(mockChannel.getDailyDataUsage()).called(1);
       });
     });
 
@@ -103,14 +103,14 @@ void main() {
       fakeAsync((async) {
         // First, simulate permission granted to start timer
         when(mockChannel.checkUsageStatsPermission()).thenAnswer((_) async => true);
-        when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+        when(mockChannel.getDailyDataUsage()).thenAnswer((_) async => 100);
         networkService.refreshPermissionAndUsage();
         async.flushMicrotasks();
         expect(networkService.hasUsageStatsPermission, isTrue);
 
         // Advance 5 minutes to verify timer is active
         async.elapse(const Duration(minutes: 5));
-        verify(mockChannel.getDailyWifiUsage()).called(2);
+        verify(mockChannel.getDailyDataUsage()).called(2);
 
         // Now deny it
         when(mockChannel.checkUsageStatsPermission()).thenAnswer((_) async => false);
@@ -129,15 +129,15 @@ void main() {
         // Advance 5 minutes, timer should NOT fire anymore
         async.elapse(const Duration(minutes: 5));
 
-        // Shouldn't have any more calls to getDailyWifiUsage since timer was cancelled
-        verifyNever(mockChannel.getDailyWifiUsage());
+        // Shouldn't have any more calls to getDailyDataUsage since timer was cancelled
+        verifyNever(mockChannel.getDailyDataUsage());
       });
     });
 
     test('when permission granted and timer is already active, does not start a new timer but fetches usage', () {
       fakeAsync((async) {
         when(mockChannel.checkUsageStatsPermission()).thenAnswer((_) async => true);
-        when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 100);
+        when(mockChannel.getDailyDataUsage()).thenAnswer((_) async => 100);
 
         // First call starts the timer
         networkService.refreshPermissionAndUsage();
@@ -146,14 +146,14 @@ void main() {
         // Advance 4 minutes, timer hasn't fired yet
         async.elapse(const Duration(minutes: 4));
 
-        when(mockChannel.getDailyWifiUsage()).thenAnswer((_) async => 200);
+        when(mockChannel.getDailyDataUsage()).thenAnswer((_) async => 200);
 
         // Second call should fetch usage but reuse the timer
         networkService.refreshPermissionAndUsage();
         async.flushMicrotasks();
 
-        expect(networkService.dailyWifiUsage, 200);
-        verify(mockChannel.getDailyWifiUsage()).called(2);
+        expect(networkService.dailyDataUsage, 200);
+        verify(mockChannel.getDailyDataUsage()).called(2);
 
         // Advance another 1 minute (total 5 mins since first call)
         // If a new timer was started, it would fire 5 mins from the second call.
@@ -161,7 +161,7 @@ void main() {
         async.elapse(const Duration(minutes: 1));
 
         // Timer fired!
-        verify(mockChannel.getDailyWifiUsage()).called(1);
+        verify(mockChannel.getDailyDataUsage()).called(1);
       });
     });
   });


### PR DESCRIPTION
Resolves the issue by extending the WiFi usage widget into a comprehensive daily/weekly/monthly Data Usage widget. The native implementation now aggregates statistics across Mobile, Ethernet, and WiFi transports. Corresponding Flutter logic, providers, and settings panels have been renamed and re-wired to properly consume and display these updated metrics under the generalized "Data Usage" title.

---
*PR created automatically by Jules for task [6152875030129803576](https://jules.google.com/task/6152875030129803576) started by @LeanBitLab*