### PR TITLE
⚡ Fix N+1 Query in TV Apps Categorization

### DIFF
--- a/lib/providers/apps_service.dart
+++ b/lib/providers/apps_service.dart
@@ -233,10 +233,8 @@ class AppsService extends ChangeNotifier {
           shouldNotifyListeners: false,
         );
         Category nonTvAppsCategory = _categoriesById[categoryId]!;
-        for (final app in nonTvApplications) {
-          await addToCategory(app, nonTvAppsCategory,
-              shouldNotifyListeners: false);
-        }
+        await addAllToCategory(nonTvApplications, nonTvAppsCategory,
+            shouldNotifyListeners: false);
       }
 
       if (tvApplications.isNotEmpty) {
@@ -244,10 +242,8 @@ class AppsService extends ChangeNotifier {
             type: CategoryType.grid, shouldNotifyListeners: false);
 
         Category tvAppsCategory = _categoriesById[categoryId]!;
-        for (final app in tvApplications) {
-          await addToCategory(app, tvAppsCategory,
-              shouldNotifyListeners: false);
-        }
+        await addAllToCategory(tvApplications, tvAppsCategory,
+            shouldNotifyListeners: false);
       }
 
       await addCategory("Favorites", shouldNotifyListeners: false);
@@ -485,24 +481,36 @@ class AppsService extends ChangeNotifier {
 
   Future<void> addToCategory(App app, Category category,
       {bool shouldNotifyListeners = true}) async {
-    int index = await _database.nextAppCategoryOrder(category.id) ?? 0;
-    await _database.insertAppsCategories([
-      AppsCategoriesCompanion.insert(
-        categoryId: category.id,
-        appPackageName: app.packageName,
-        order: index,
-      )
-    ]);
+    await addAllToCategory([app], category,
+        shouldNotifyListeners: shouldNotifyListeners);
+  }
+
+  Future<void> addAllToCategory(Iterable<App> apps, Category category,
+      {bool shouldNotifyListeners = true}) async {
+    if (apps.isEmpty) return;
 
     final categoryFound = _categoriesById[category.id];
-    if (categoryFound != null) {
-      app.categoryOrders[categoryFound.id] = index;
-      categoryFound.applications.add(app);
+    if (categoryFound == null) return;
 
-      if (shouldNotifyListeners) {
-        sortCategory(categoryFound);
-        notifyListeners();
-      }
+    int nextOrder = await _database.nextAppCategoryOrder(categoryFound.id) ?? 0;
+    List<AppsCategoriesCompanion> batch = [];
+
+    for (final app in apps) {
+      batch.add(AppsCategoriesCompanion.insert(
+        categoryId: categoryFound.id,
+        appPackageName: app.packageName,
+        order: nextOrder,
+      ));
+      app.categoryOrders[categoryFound.id] = nextOrder;
+      categoryFound.applications.add(app);
+      nextOrder++;
+    }
+
+    await _database.insertAppsCategories(batch);
+
+    if (shouldNotifyListeners) {
+      sortCategory(categoryFound);
+      notifyListeners();
     }
   }
 
@@ -542,28 +550,7 @@ class AppsService extends ChangeNotifier {
         return; // Not a special category
     }
 
-    if (appsToAdd.isEmpty) {
-      return;
-    }
-
-    int nextOrder =
-        await _database.nextAppCategoryOrder(actualCategory.id) ?? 0;
-    List<AppsCategoriesCompanion> batch = [];
-
-    for (final app in appsToAdd) {
-      batch.add(AppsCategoriesCompanion.insert(
-        categoryId: actualCategory.id,
-        appPackageName: app.packageName,
-        order: nextOrder,
-      ));
-      app.categoryOrders[actualCategory.id] = nextOrder;
-      actualCategory.applications.add(app);
-      nextOrder++;
-    }
-
-    await _database.insertAppsCategories(batch);
-    sortCategory(actualCategory);
-    notifyListeners();
+    await addAllToCategory(appsToAdd, actualCategory);
   }
 
   // === FAVORITES METHODS ===

--- a/test/apps_service_benchmark_v2.dart
+++ b/test/apps_service_benchmark_v2.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flauncher/database.dart';
+import 'package:flauncher/providers/apps_service.dart';
+import 'package:flauncher/flauncher_channel.dart';
+import 'package:mockito/mockito.dart';
+import 'package:flauncher/models/app.dart';
+import 'package:flauncher/models/category.dart';
+
+import 'mocks.mocks.dart';
+
+void main() {
+  late FLauncherDatabase database;
+  late MockFLauncherChannel mockChannel;
+  late AppsService appsService;
+
+  setUp(() async {
+    database = FLauncherDatabase.inMemory();
+    mockChannel = MockFLauncherChannel();
+
+    // Minimal mock for getApplications to avoid crash in _refreshState
+    when(mockChannel.getApplications()).thenAnswer((_) async => []);
+
+    appsService = AppsService(mockChannel, database);
+    // Wait for initialization
+    while (!appsService.initialized) {
+      await Future.delayed(Duration(milliseconds: 10));
+    }
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('Benchmark addToCategory in loop vs addAllToCategory', () async {
+    const int numApps = 100;
+
+    // Pre-create apps and categories
+    int categoryId1 = await appsService.addCategory("Loop Category", shouldNotifyListeners: false);
+    Category category1 = appsService.categories.firstWhere((c) => c.id == categoryId1);
+
+    int categoryId2 = await appsService.addCategory("Batch Category", shouldNotifyListeners: false);
+    Category category2 = appsService.categories.firstWhere((c) => c.id == categoryId2);
+
+    List<App> appsToAdd1 = List.generate(numApps, (i) => App(
+      packageName: 'com.example.app_loop$i',
+      name: 'App $i',
+      version: '1.0.0',
+      hidden: false,
+    ));
+
+    List<App> appsToAdd2 = List.generate(numApps, (i) => App(
+      packageName: 'com.example.app_batch$i',
+      name: 'App $i',
+      version: '1.0.0',
+      hidden: false,
+    ));
+
+    // Baseline: Loop
+    final swLoop = Stopwatch()..start();
+    for (final app in appsToAdd1) {
+      await appsService.addToCategory(app, category1, shouldNotifyListeners: false);
+    }
+    swLoop.stop();
+
+    // Batch
+    final swBatch = Stopwatch()..start();
+    await appsService.addAllToCategory(appsToAdd2, category2, shouldNotifyListeners: false);
+    swBatch.stop();
+
+    print('LOOP: Adding $numApps apps took ${swLoop.elapsedMilliseconds}ms');
+    print('BATCH: Adding $numApps apps took ${swBatch.elapsedMilliseconds}ms');
+
+    if (swBatch.elapsedMilliseconds < swLoop.elapsedMilliseconds) {
+        print('OPTIMIZATION: Batch was ${swLoop.elapsedMilliseconds - swBatch.elapsedMilliseconds}ms faster');
+    }
+  });
+}

--- a/test/providers/apps_service_batch_test.dart
+++ b/test/providers/apps_service_batch_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flauncher/database.dart';
+import 'package:flauncher/providers/apps_service.dart';
+import 'package:flauncher/flauncher_channel.dart';
+import 'package:mockito/mockito.dart';
+import 'package:flauncher/models/app.dart';
+import 'package:flauncher/models/category.dart';
+
+import 'mocks.mocks.dart';
+
+void main() {
+  late FLauncherDatabase database;
+  late MockFLauncherChannel mockChannel;
+  late AppsService appsService;
+
+  setUp(() async {
+    database = FLauncherDatabase.inMemory();
+    mockChannel = MockFLauncherChannel();
+
+    // Minimal mock for getApplications to avoid crash in _refreshState
+    when(mockChannel.getApplications()).thenAnswer((_) async => []);
+
+    appsService = AppsService(mockChannel, database);
+    // Wait for initialization
+    while (!appsService.initialized) {
+      await Future.delayed(Duration(milliseconds: 10));
+    }
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('Test addAllToCategory functionality', () async {
+    const int numApps = 10;
+    int categoryId = await appsService.addCategory("Test Category", shouldNotifyListeners: false);
+    Category category = appsService.categories.firstWhere((c) => c.id == categoryId);
+
+    List<App> appsToAdd = List.generate(numApps, (i) => App(
+      packageName: 'com.example.app$i',
+      name: 'App $i',
+      version: '1.0.0',
+      hidden: false,
+    ));
+
+    await appsService.addAllToCategory(appsToAdd, category);
+
+    expect(category.applications.length, numApps);
+    for (int i = 0; i < numApps; i++) {
+      expect(appsToAdd[i].categoryOrders[category.id], i);
+      expect(category.applications[i].packageName, appsToAdd[i].packageName);
+    }
+
+    final dbAppsCategories = await database.getAppsCategories();
+    expect(dbAppsCategories.length, numApps);
+  });
+}


### PR DESCRIPTION
💡 **What:** Implemented `addAllToCategory` in `AppsService` to perform batch insertions of apps into categories and refactored initialization and auto-population logic to use it.

🎯 **Why:** The previous implementation added apps one by one in a loop, causing 2N database queries (one for determining the order and one for the insertion). The new approach uses a single query to determine the starting order and a single batch insert, reducing database overhead to 2 operations regardless of the number of apps.

📊 **Measured Improvement:** While live benchmarking was hampered by environment timeouts, the architectural improvement from O(N) to O(1) database transactions per batch operation ensures significant performance gains, especially during initial setup or when handling large numbers of apps. A functional test and benchmark suite were added to verify correctness and demonstrate the optimization path.

---
*PR created automatically by Jules for task [1724513109127415083](https://jules.google.com/task/1724513109127415083) started by @LeanBitLab*