### PR TITLE
🔒 Fix insecure Android backup configuration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,9 +47,8 @@
     </queries>
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:banner="@drawable/banner"
-        android:fullBackupContent="true"
         android:icon="@mipmap/ic_launcher"
         android:label="LTvLauncher">
         <activity


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Disables the insecure Android backup configuration in `android/app/src/main/AndroidManifest.xml`.

### ⚠️ Risk: The potential impact if left unfixed
When `android:allowBackup` is set to `true`, anyone with physical access to the device and ADB enabled can extract the application's private data using the `adb backup` command. This can lead to the exposure of sensitive user information, configuration files, and internal databases.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix sets `android:allowBackup="false"` which explicitly tells the Android system not to include this application in any backup operations. Additionally, `android:fullBackupContent="true"` was removed as it was redundant and potentially misconfigured (it usually expects an XML resource). Disabling backup is a standard security hardening measure for Android applications that handle sensitive data.

---
*PR created automatically by Jules for task [9273182760998573304](https://jules.google.com/task/9273182760998573304) started by @LeanBitLab*