### PR TITLE
🧹 Code Health Improvement: Replace `print` with `log` in NetworkService

### DIFF
--- a/lib/providers/network_service.dart
+++ b/lib/providers/network_service.dart
@@ -17,6 +17,7 @@
  */
 
 import 'dart:async';
+import 'dart:developer';
 import 'package:flauncher/flauncher_channel.dart';
 import 'package:flutter/material.dart';
 
@@ -86,7 +87,7 @@ class NetworkService extends ChangeNotifier
             notifyListeners();
           }
         }).catchError((e) {
-          print("Error getting active network info: $e");
+          log("Error getting active network info: $e");
         });
 
     _checkPermissionAndStartPolling();
@@ -174,7 +175,7 @@ class NetworkService extends ChangeNotifier
 
   void _getNetworkInformation(Map<String, dynamic> map)
   {
-    print("NetworkService: _getNetworkInformation: $map");
+    log("NetworkService: _getNetworkInformation: $map");
     try {
       int networkTypeInt = map["networkType"] as int;
       _hasInternetAccess = map["internetAccess"] as bool;
@@ -183,9 +184,9 @@ class NetworkService extends ChangeNotifier
       if (_networkType == NetworkType.Cellular || _networkType == NetworkType.Wifi) {
         _wirelessNetworkSignalLevel = map["wirelessSignalLevel"] as int;
       }
-      print("NetworkService: parsed type $_networkType, signal $_wirelessNetworkSignalLevel");
+      log("NetworkService: parsed type $_networkType, signal $_wirelessNetworkSignalLevel");
     } catch (e) {
-      print("NetworkService error parsing: $e");
+      log("NetworkService error parsing: $e");
     }
   }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was replacing standard `print` statements with `log` from `dart:developer` in `lib/providers/network_service.dart`.
💡 **Why:** This improves maintainability and robustness by using standard robust logging instead of simple `print` calls, which can cause unneeded output noise and aren't easy to filter.
✅ **Verification:** Ran `flutter test test/providers/network_service_test.dart` and `flutter test test/network_service_debug_test.dart` to verify that no core functionalities were negatively impacted by the refactoring change.
✨ **Result:** The improvement successfully addressed code health metrics related to print usage by converting the print statements to the more robust `dart:developer` `log` function.

---
*PR created automatically by Jules for task [9198637711312378769](https://jules.google.com/task/9198637711312378769) started by @LeanBitLab*