### PR TITLE
🧹 Replace error print with logger in NetworkService

### DIFF
--- a/lib/providers/network_service.dart
+++ b/lib/providers/network_service.dart
@@ -17,6 +17,7 @@
  */
 
 import 'dart:async';
+import 'dart:developer';
 import 'package:flauncher/flauncher_channel.dart';
 import 'package:flutter/material.dart';
 
@@ -86,7 +87,7 @@ class NetworkService extends ChangeNotifier
             notifyListeners();
           }
         }).catchError((e) {
-          print("Error getting active network info: $e");
+          log("Error getting active network info: $e", name: 'NetworkService', error: e);
         });
 
     _checkPermissionAndStartPolling();
@@ -174,7 +175,7 @@ class NetworkService extends ChangeNotifier
 
   void _getNetworkInformation(Map<String, dynamic> map)
   {
-    print("NetworkService: _getNetworkInformation: $map");
+    log("_getNetworkInformation: $map", name: 'NetworkService');
     try {
       int networkTypeInt = map["networkType"] as int;
       _hasInternetAccess = map["internetAccess"] as bool;
@@ -183,9 +184,9 @@ class NetworkService extends ChangeNotifier
       if (_networkType == NetworkType.Cellular || _networkType == NetworkType.Wifi) {
         _wirelessNetworkSignalLevel = map["wirelessSignalLevel"] as int;
       }
-      print("NetworkService: parsed type $_networkType, signal $_wirelessNetworkSignalLevel");
+      log("parsed type $_networkType, signal $_wirelessNetworkSignalLevel", name: 'NetworkService');
     } catch (e) {
-      print("NetworkService error parsing: $e");
+      log("error parsing: $e", name: 'NetworkService', error: e);
     }
   }
 


### PR DESCRIPTION
### 🎯 What:
Replaced `print` statements in `lib/providers/network_service.dart` with `dart:developer`'s `log` function.

### 💡 Why:
Using `log` instead of `print` is a better practice in Flutter/Dart as it allows for structured logging, filtering by name (in this case `NetworkService`), and better handling of error objects in the developer console.

### ✅ Verification:
- Manual code review of the changes.
- Verified the code structure and syntax by reading the file back.
- Received a positive code review (#Correct#).
- (Note: Full test suite execution timed out due to environment constraints, but the user approved proceeding given the low-risk nature of the change).

### ✨ Result:
Improved code health and maintainability by using proper logging mechanisms.

---
*PR created automatically by Jules for task [667465148693018292](https://jules.google.com/task/667465148693018292) started by @LeanBitLab*