### PR TITLE
🧪 [testing] Improve NetworkWidget test coverage

### DIFF
--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -23,6 +23,7 @@ import 'package:flauncher/flauncher_channel.dart';
 import 'package:flauncher/providers/apps_service.dart';
 import 'package:flauncher/providers/settings_service.dart';
 import 'package:flauncher/providers/wallpaper_service.dart';
+import 'package:flauncher/providers/network_service.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mockito/annotations.dart';
@@ -35,6 +36,7 @@ import 'package:flauncher/models/category.dart';
   WallpaperService,
   AppsService,
   SettingsService,
+  NetworkService,
   ImagePicker,
 ], customMocks: [
   MockSpec<FLauncherDatabase>(unsupportedMembers: {#alias}),

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -15,6 +15,7 @@ import 'package:flauncher/gradients.dart' as _i2;
 import 'package:flauncher/models/app.dart' as _i16;
 import 'package:flauncher/models/category.dart' as _i3;
 import 'package:flauncher/providers/apps_service.dart' as _i15;
+import 'package:flauncher/providers/network_service.dart' as _i19;
 import 'package:flauncher/providers/settings_service.dart' as _i17;
 import 'package:flauncher/providers/wallpaper_service.dart' as _i14;
 import 'package:flutter/cupertino.dart' as _i10;
@@ -862,6 +863,25 @@ class MockAppsService extends _i1.Mock implements _i15.AppsService {
       ) as _i9.Future<void>);
 
   @override
+  _i9.Future<void> addAllToCategory(
+    Iterable<_i16.App>? apps,
+    _i3.Category? category, {
+    bool? shouldNotifyListeners = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addAllToCategory,
+          [
+            apps,
+            category,
+          ],
+          {#shouldNotifyListeners: shouldNotifyListeners},
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
   _i9.Future<void> removeFromCategory(
     _i16.App? application,
     _i3.Category? category,
@@ -1671,6 +1691,132 @@ class MockSettingsService extends _i1.Mock implements _i17.SettingsService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [NetworkService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
+  MockNetworkService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  bool get hasInternetAccess => (super.noSuchMethod(
+        Invocation.getter(#hasInternetAccess),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i19.CellularNetworkType get cellularNetworkType => (super.noSuchMethod(
+        Invocation.getter(#cellularNetworkType),
+        returnValue: _i19.CellularNetworkType.Unknown,
+      ) as _i19.CellularNetworkType);
+
+  @override
+  _i19.NetworkType get networkType => (super.noSuchMethod(
+        Invocation.getter(#networkType),
+        returnValue: _i19.NetworkType.Cellular,
+      ) as _i19.NetworkType);
+
+  @override
+  int get wirelessNetworkSignalLevel => (super.noSuchMethod(
+        Invocation.getter(#wirelessNetworkSignalLevel),
+        returnValue: 0,
+      ) as int);
+
+  @override
+  int get dailyDataUsage => (super.noSuchMethod(
+        Invocation.getter(#dailyDataUsage),
+        returnValue: 0,
+      ) as int);
+
+  @override
+  bool get hasUsageStatsPermission => (super.noSuchMethod(
+        Invocation.getter(#hasUsageStatsPermission),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i9.Future<void> requestPermission() => (super.noSuchMethod(
+        Invocation.method(
+          #requestPermission,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> refreshPermissionAndUsage() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshPermissionAndUsage,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<void> openWifiSettings() => (super.noSuchMethod(
+        Invocation.method(
+          #openWifiSettings,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
+  _i9.Future<int> getDataUsageForPeriod(String? period) => (super.noSuchMethod(
+        Invocation.method(
+          #getDataUsageForPeriod,
+          [period],
+        ),
+        returnValue: _i9.Future<int>.value(0),
+      ) as _i9.Future<int>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/network_widget_test.dart
+++ b/test/widgets/network_widget_test.dart
@@ -1,0 +1,209 @@
+import 'package:flauncher/providers/network_service.dart';
+import 'package:flauncher/widgets/network_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:mockito/mockito.dart';
+import '../mocks.mocks.dart';
+
+void main() {
+  late MockNetworkService mockNetworkService;
+
+  setUp(() {
+    mockNetworkService = MockNetworkService();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: Scaffold(
+        body: ChangeNotifierProvider<NetworkService>.value(
+          value: mockNetworkService,
+          child: const NetworkWidget(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders link_off icon and red color when network state is Unknown', (WidgetTester tester) async {
+    when(mockNetworkService.networkType).thenReturn(NetworkType.Unknown);
+    when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+    when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    final iconFinder = find.byType(Icon);
+    expect(iconFinder, findsOneWidget);
+
+    final iconWidget = tester.widget<Icon>(iconFinder);
+    expect(iconWidget.icon, Icons.link_off);
+    expect(iconWidget.color, Colors.red);
+  });
+
+  group('Wifi Network', () {
+    testWidgets('renders signal_wifi_0_bar when signal is 0', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Wifi);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.signal_wifi_0_bar), findsOneWidget);
+    });
+
+    testWidgets('renders signal_wifi_1_bar when signal is 1', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Wifi);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(1);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.network_wifi_1_bar), findsOneWidget);
+    });
+
+    testWidgets('renders signal_wifi_2_bar when signal is 2', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Wifi);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(2);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.network_wifi_2_bar), findsOneWidget);
+    });
+
+    testWidgets('renders signal_wifi_3_bar when signal is 3', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Wifi);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(3);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.network_wifi_3_bar), findsOneWidget);
+    });
+
+    testWidgets('renders signal_wifi_4_bar when signal is 4 or higher', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Wifi);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(4);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.signal_wifi_4_bar), findsOneWidget);
+    });
+  });
+
+  group('Cellular Network', () {
+    testWidgets('renders g_mobiledata for GPRS/EDGE/CDMA', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Gprs);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.g_mobiledata), findsOneWidget);
+    });
+
+    testWidgets('renders e_mobiledata for EDGE', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Edge);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.e_mobiledata), findsOneWidget);
+    });
+
+    testWidgets('renders h_mobiledata for HSPA/HSDPA/HSUPA', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Hspa);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.h_mobiledata), findsOneWidget);
+    });
+
+    testWidgets('renders h_plus_mobiledata for HSPAP', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Hspap);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.h_plus_mobiledata), findsOneWidget);
+    });
+
+    testWidgets('renders three_g_mobiledata for UMTS/TD_SCDMA', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Umts);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.three_g_mobiledata), findsOneWidget);
+    });
+
+    testWidgets('renders four_g_mobiledata_outlined for LTE', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Lte);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.four_g_mobiledata_outlined), findsOneWidget);
+    });
+
+    testWidgets('renders five_g for NR', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Nr);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.five_g), findsOneWidget);
+    });
+
+    testWidgets('renders question_mark for other cellular types', (WidgetTester tester) async {
+      when(mockNetworkService.networkType).thenReturn(NetworkType.Cellular);
+      when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+      when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byIcon(Icons.question_mark), findsOneWidget);
+    });
+  });
+
+  testWidgets('renders vpn_key when network type is VPN', (WidgetTester tester) async {
+    when(mockNetworkService.networkType).thenReturn(NetworkType.Vpn);
+    when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+    when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.byIcon(Icons.vpn_key), findsOneWidget);
+  });
+
+  testWidgets('renders lan when network type is Wired', (WidgetTester tester) async {
+    when(mockNetworkService.networkType).thenReturn(NetworkType.Wired);
+    when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+    when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.byIcon(Icons.lan), findsOneWidget);
+  });
+
+  testWidgets('tapping the widget opens wifi settings', (WidgetTester tester) async {
+    when(mockNetworkService.networkType).thenReturn(NetworkType.Unknown);
+    when(mockNetworkService.cellularNetworkType).thenReturn(CellularNetworkType.Unknown);
+    when(mockNetworkService.wirelessNetworkSignalLevel).thenReturn(0);
+    when(mockNetworkService.openWifiSettings()).thenAnswer((_) => Future.value());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.tap(find.byType(InkWell));
+    await tester.pumpAndSettle();
+
+    verify(mockNetworkService.openWifiSettings()).called(1);
+  });
+}


### PR DESCRIPTION
🎯 **What:** 
Missing tests for `NetworkWidget` which previously had no coverage.

📊 **Coverage:**
- Wifi Network scenarios mapping signal levels (0 through 4) to `Icons.signal_wifi_*_bar`.
- Cellular Network scenarios handling different standards (GPRS, EDGE, HSPA, UMTS, LTE, NR) mapping to the appropriate mobile data icons (`Icons.g_mobiledata`, `Icons.e_mobiledata`, `Icons.four_g_mobiledata_outlined`, `Icons.five_g`, etc.).
- Wired Network scenario mapping to `Icons.lan`.
- VPN Network scenario mapping to `Icons.vpn_key`.
- Unknown/Offline scenario verifying that a red `Icons.link_off` is displayed.
- User Interaction simulating a tap on the widget to trigger `openWifiSettings` on the `NetworkService`.

✨ **Result:**
The testing gap is successfully filled. Refactoring `NetworkWidget` or changes to `NetworkService` logic can now be done with confidence, knowing the UI visually reflects connection state appropriately.

---
*PR created automatically by Jules for task [7905267197070535751](https://jules.google.com/task/7905267197070535751) started by @LeanBitLab*