### PR TITLE
🧪 [testing improvement] Add widget test for SidePanelDialog

### DIFF
--- a/test/widgets/side_panel_dialog_test.dart
+++ b/test/widgets/side_panel_dialog_test.dart
@@ -1,0 +1,121 @@
+import 'package:flauncher/widgets/side_panel_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('SidePanelDialog renders default state correctly', (WidgetTester tester) async {
+    const testChild = Text('Test Content');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SidePanelDialog(
+            child: testChild,
+          ),
+        ),
+      ),
+    );
+
+    // Verify child is rendered
+    expect(find.text('Test Content'), findsOneWidget);
+
+    // Verify Align is centerLeft
+    final alignFinder = find.byType(Align).first;
+    expect(alignFinder, findsOneWidget);
+    final Align alignWidget = tester.widget(alignFinder);
+    expect(alignWidget.alignment, Alignment.centerLeft);
+
+    // Verify Material border radius (find the specific Material widget we created)
+    final materialFinder = find.byType(Material);
+    final Material materialWidget = tester.widgetList<Material>(materialFinder).firstWhere(
+      (m) => m.elevation == 24,
+    );
+    expect(
+      materialWidget.borderRadius,
+      const BorderRadius.horizontal(
+        right: Radius.circular(28),
+        left: Radius.zero,
+      ),
+    );
+
+    // Verify Container width (default is 250)
+    // Find the container directly under the Material we verified above
+    final containerFinder = find.descendant(
+      of: find.byWidget(materialWidget),
+      matching: find.byType(Container),
+    ).first;
+    final Container containerWidget = tester.widget(containerFinder);
+    expect(containerWidget.constraints?.maxWidth, 250);
+  });
+
+  testWidgets('SidePanelDialog renders correctly when isRightSide is true', (WidgetTester tester) async {
+    const testChild = Text('Test Content');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SidePanelDialog(
+            child: testChild,
+            isRightSide: true,
+          ),
+        ),
+      ),
+    );
+
+    // Verify child is rendered
+    expect(find.text('Test Content'), findsOneWidget);
+
+    // Verify Align is centerRight
+    final alignFinder = find.byType(Align).first;
+    expect(alignFinder, findsOneWidget);
+    final Align alignWidget = tester.widget(alignFinder);
+    expect(alignWidget.alignment, Alignment.centerRight);
+
+    // Verify Material border radius (find the specific Material widget we created)
+    final materialFinder = find.byType(Material);
+    final Material materialWidget = tester.widgetList<Material>(materialFinder).firstWhere(
+      (m) => m.elevation == 24,
+    );
+    expect(
+      materialWidget.borderRadius,
+      const BorderRadius.horizontal(
+        right: Radius.zero,
+        left: Radius.circular(28),
+      ),
+    );
+  });
+
+
+  testWidgets('SidePanelDialog respects custom width', (WidgetTester tester) async {
+    const testChild = Text('Test Content');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SidePanelDialog(
+            child: testChild,
+            width: 400.0,
+          ),
+        ),
+      ),
+    );
+
+    // Verify child is rendered
+    expect(find.text('Test Content'), findsOneWidget);
+
+    // Verify Material widget
+    final materialFinder = find.byType(Material);
+    final Material materialWidget = tester.widgetList<Material>(materialFinder).firstWhere(
+      (m) => m.elevation == 24,
+    );
+
+    // Verify Container width is 400.0
+    final containerFinder = find.descendant(
+      of: find.byWidget(materialWidget),
+      matching: find.byType(Container),
+    ).first;
+    final Container containerWidget = tester.widget(containerFinder);
+    expect(containerWidget.constraints?.maxWidth, 400.0);
+  });
+
+}


### PR DESCRIPTION
### 🎯 **What:**
Added a missing test file (`test/widgets/side_panel_dialog_test.dart`) to provide test coverage for `SidePanelDialog`, a custom stateless widget defining a dialog frame UI.

### 📊 **Coverage:**
The added test scenarios cover:
1.  **Default Rendering:** Verifies that the internal `Align` correctly defaults to `Alignment.centerLeft`, checks the default shape (`borderRadius`), and verifies the `Container` respects the default width (250).
2.  **Alignment Adjustments (`isRightSide`):** Verifies that supplying `isRightSide = true` accurately updates the `Align` to `Alignment.centerRight` and alters the `BorderRadius` appropriately (setting the right side to zero instead of the left).
3.  **Width Constraints:** Asserts that supplying a custom `width` updates the underlying constraint successfully.

### ✨ **Result:**
The test fully covers `SidePanelDialog` ensuring confidence that styling modifications to this dialog wrapper won't quietly break visibility or dimension expectations. All added tests pass successfully!

---
*PR created automatically by Jules for task [15516445715521691482](https://jules.google.com/task/15516445715521691482) started by @LeanBitLab*