### PR TITLE
test: Add FocusAwareAppBar widget tests

### DIFF
--- a/test/widgets/focus_aware_app_bar_test.dart
+++ b/test/widgets/focus_aware_app_bar_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flauncher/widgets/focus_aware_app_bar.dart';
+import 'package:flauncher/providers/settings_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mockito/mockito.dart';
+import '../mocks.mocks.dart';
+
+void main() {
+  late MockSettingsService mockSettingsService;
+
+  setUp(() {
+    mockSettingsService = MockSettingsService();
+    // Default mock setup
+    when(mockSettingsService.autoHideAppBarEnabled).thenReturn(false);
+    when(mockSettingsService.showNetworkIndicatorInStatusBar).thenReturn(false);
+    when(mockSettingsService.showDataWidgetInStatusBar).thenReturn(false);
+    when(mockSettingsService.showDateInStatusBar).thenReturn(true);
+    when(mockSettingsService.showTimeInStatusBar).thenReturn(true);
+    when(mockSettingsService.dateFormat).thenReturn(SettingsService.defaultDateFormat);
+    when(mockSettingsService.timeFormat).thenReturn(SettingsService.defaultTimeFormat);
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: FocusAwareAppBar(),
+        body: Container(),
+      ),
+    );
+  }
+
+  testWidgets('FocusAwareAppBar renders settings button and date/time widgets', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<SettingsService>.value(value: mockSettingsService),
+        ],
+        child: createWidgetUnderTest(),
+      )
+    );
+
+    expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
+    expect(find.byKey(const Key('statusbar_date')), findsOneWidget);
+    expect(find.byKey(const Key('statusbar_clock')), findsOneWidget);
+  });
+
+  testWidgets('FocusAwareAppBar auto-hide logic', (WidgetTester tester) async {
+    when(mockSettingsService.autoHideAppBarEnabled).thenReturn(true);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<SettingsService>.value(value: mockSettingsService),
+        ],
+        child: createWidgetUnderTest(),
+      )
+    );
+
+    // Initial state: app bar height should be 0 because auto-hide is true and focused is false
+    final animatedContainer = tester.widget<AnimatedContainer>(find.byType(AnimatedContainer));
+    expect(animatedContainer.constraints?.maxHeight, 0);
+
+    // Trigger focus to show app bar
+    final focusWidget = tester.widget<Focus>(find.descendant(of: find.byType(FocusAwareAppBar), matching: find.byType(Focus)).first);
+    focusWidget.onFocusChange?.call(true);
+
+    await tester.pumpAndSettle();
+
+    // After focus: app bar height should be kToolbarHeight
+    final animatedContainerFocused = tester.widget<AnimatedContainer>(find.byType(AnimatedContainer));
+    expect(animatedContainerFocused.constraints?.maxHeight, kToolbarHeight);
+  });
+}


### PR DESCRIPTION
🧪 **Testing Improvement**

🎯 **What:** The `FocusAwareAppBar` widget was lacking test coverage for its focus-driven auto-hide behavior and element rendering. Added a new test file `test/widgets/focus_aware_app_bar_test.dart` to address this gap.

📊 **Coverage:** 
- The rendering of the settings button, date, and clock widgets.
- The `FocusAwareAppBar` auto-hide animation logic triggered via focus changes (verifying `kToolbarHeight` vs `0` height).

✨ **Result:** `FocusAwareAppBar` is now explicitly tested, ensuring its core view state and dynamic focus transitions remain robust against future regressions.

---
*PR created automatically by Jules for task [3421012887930503100](https://jules.google.com/task/3421012887930503100) started by @LeanBitLab*