### PR TITLE
⚡ test: Fix AppsService batch categorization benchmark and test

### DIFF
--- a/test/apps_service_benchmark_v2.dart
+++ b/test/apps_service_benchmark_v2.dart
@@ -5,6 +5,7 @@ import 'package:flauncher/flauncher_channel.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flauncher/models/app.dart';
 import 'package:flauncher/models/category.dart';
+import 'package:drift/drift.dart';
 
 import 'mocks.mocks.dart';
 
@@ -54,6 +55,18 @@ void main() {
       version: '1.0.0',
       hidden: false,
     ));
+
+    // Insert apps into DB before categorizing them
+    await database.persistApps(appsToAdd1.map((app) => AppsCompanion(
+        packageName: Value(app.packageName),
+        name: Value(app.name),
+        version: Value(app.version),
+    )));
+    await database.persistApps(appsToAdd2.map((app) => AppsCompanion(
+        packageName: Value(app.packageName),
+        name: Value(app.name),
+        version: Value(app.version),
+    )));
 
     // Baseline: Loop
     final swLoop = Stopwatch()..start();

--- a/test/providers/apps_service_batch_test.dart
+++ b/test/providers/apps_service_batch_test.dart
@@ -5,8 +5,9 @@ import 'package:flauncher/flauncher_channel.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flauncher/models/app.dart';
 import 'package:flauncher/models/category.dart';
+import 'package:drift/drift.dart';
 
-import 'mocks.mocks.dart';
+import '../mocks.mocks.dart';
 
 void main() {
   late FLauncherDatabase database;
@@ -42,6 +43,12 @@ void main() {
       version: '1.0.0',
       hidden: false,
     ));
+
+    await database.persistApps(appsToAdd.map((app) => AppsCompanion(
+        packageName: Value(app.packageName),
+        name: Value(app.name),
+        version: Value(app.version),
+    )));
 
     await appsService.addAllToCategory(appsToAdd, category);
 


### PR DESCRIPTION
### 💡 What
- Fixed `test/apps_service_benchmark_v2.dart` to insert apps into the database (`database.persistApps()`) before categorizing them.
- Fixed `test/providers/apps_service_batch_test.dart` to correct the mock import path and similarly insert apps before categorizing them.

### 🎯 Why
The codebase already contained the performance fix replacing an N+1 query loop with a batch insert `addAllToCategory` in `lib/providers/apps_service.dart`. However, the related test and benchmark test that verify this performance boost were failing due to a SQLite Foreign Key constraint error (code 787). `apps_categories` references `apps`, so the apps needed to exist in the database before categorization.

### 📊 Measured Improvement
The `test/apps_service_benchmark_v2.dart` benchmark now executes successfully.

**Results for 100 Apps:**
- **Baseline (Loop):** ~164ms
- **Optimized (Batch):** ~5ms
- **Improvement:** The batch method is ~159ms faster than the loop method.

---
*PR created automatically by Jules for task [6809146516485165093](https://jules.google.com/task/6809146516485165093) started by @LeanBitLab*