### PR TITLE
Fix wallpaper not immediately updating after changing

### DIFF
--- a/lib/flauncher.dart
+++ b/lib/flauncher.dart
@@ -141,7 +141,7 @@ class _FLauncherState extends State<FLauncher> {
       final physicalSize = MediaQuery.sizeOf(context);
       return Image(
         image: wallpaperService.wallpaper!,
-        key: const Key("background"),
+        key: Key("background_${wallpaperService.version}"),
         fit: BoxFit.cover,
         height: physicalSize.height,
         width: physicalSize.width

--- a/lib/providers/wallpaper_service.dart
+++ b/lib/providers/wallpaper_service.dart
@@ -36,8 +36,10 @@ class WallpaperService extends ChangeNotifier {
   Timer? _timer;
 
   ImageProvider? _wallpaper;
+  int _version = 0;
 
   ImageProvider?  get wallpaper     => _wallpaper;
+  int             get version       => _version;
 
   FLauncherGradient get gradient => FLauncherGradients.all.firstWhere(
         (gradient) => gradient.uuid == _settingsService.gradientUuid,
@@ -145,6 +147,7 @@ class WallpaperService extends ChangeNotifier {
       // Evict from cache to ensure UI updates
       await FileImage(targetFile).evict();
 
+      _version++;
       _updateWallpaper(force: true);
     }
   }


### PR DESCRIPTION
Fix wallpaper not immediately updating after changing

When setting a new wallpaper with time-based wallpaper enabled, the new image might overwrite the previous file at the exact same path. In Flutter, `FileImage` checks for equality based on the file path. Simply evicting the cache doesn't trigger an update because the ImageProvider is considered unchanged.

To resolve this, we introduce a `version` variable in `WallpaperService` that increments every time a new wallpaper is successfully saved. The `FLauncher` widget then consumes this version as part of the `Key` for the `Image` widget. Changing the key forces the framework to discard the old widget and build a new one, fetching the fresh file from disk.

---
*PR created automatically by Jules for task [9672192931307567520](https://jules.google.com/task/9672192931307567520) started by @LeanBitLab*