### PR TITLE
🧹 refactor: remove unused `_swatch` variable in `flauncher_app.dart`

### DIFF
--- a/lib/flauncher_app.dart
+++ b/lib/flauncher_app.dart
@@ -36,19 +36,6 @@ class FLauncherApp extends StatelessWidget
     BackIntent()
   ]);
 
-  static const MaterialColor _swatch = MaterialColor(0xFF011526, <int, Color>{
-    50: Color(0xFF36A0FA),
-    100: Color(0xFF067BDE),
-    200: Color(0xFF045CA7),
-    300: Color(0xFF033662),
-    400: Color(0xFF022544),
-    500: Color(0xFF011526),
-    600: Color(0xFF000508),
-    700: Color(0xFF000000),
-    800: Color(0xFF000000),
-    900: Color(0xFF000000),
-  });
-
   const FLauncherApp();
 
   @override


### PR DESCRIPTION
🎯 **What:** Removed the entirely unused `_swatch` private `MaterialColor` variable from `lib/flauncher_app.dart`.
💡 **Why:** A static analyzer warning indicated this variable is dead code. Removing it improves codebase cleanliness.
✅ **Verification:** Verified via `flutter analyze` that the warning is gone and the file is free of new errors. Existing functionality is not affected because the constant was not being used anywhere.
✨ **Result:** Cleaned up code health with no functional regressions.

---
*PR created automatically by Jules for task [10803040634688039088](https://jules.google.com/task/10803040634688039088) started by @LeanBitLab*