### PR TITLE
🧹 fix unused local variables in app_card_test.dart

### DIFF
--- a/test/widgets/app_card_test.dart
+++ b/test/widgets/app_card_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flauncher/models/app.dart';
 import 'package:flauncher/models/category.dart';
 import 'package:flauncher/providers/apps_service.dart';
@@ -126,14 +124,10 @@ void main() {
       tester.view.resetDevicePixelRatio();
     });
 
-    AxisDirection? movedDirection;
-    await tester.pumpWidget(createWidgetUnderTest(
-      onMove: (dir) => movedDirection = dir,
-    ));
+    await tester.pumpWidget(createWidgetUnderTest());
     await tester.pumpAndSettle();
 
     // Use a small hack to trigger the private state _moving logic so we can test the public callbacks without relying on the complex private dialog and nested navigator hierarchy logic
-    final state = tester.state(find.byType(AppCard)) as dynamic;
 
     // Setting _moving directly fails but we can just use the exposed callback to fake it
     // Or we just test bump navigation
@@ -154,10 +148,7 @@ void main() {
       tester.view.resetDevicePixelRatio();
     });
 
-    bool moveEnded = false;
-    await tester.pumpWidget(createWidgetUnderTest(
-      onMoveEnd: () => moveEnded = true,
-    ));
+    await tester.pumpWidget(createWidgetUnderTest());
     await tester.pumpAndSettle();
 
     // Skip testing private move state since it's hard to trigger without full framework Context.


### PR DESCRIPTION
🎯 **What:** Removed unused variables (`movedDirection`, `state`, `moveEnded`) and their assignments in test callbacks within `test/widgets/app_card_test.dart`. Also removed an unused `dart:typed_data` import.

💡 **Why:** These variables were declared but never used in assertions or logic. Their presence caused `unused_local_variable` and `unused_import` lint warnings. Removing them cleans up the test code, removing dead logic and making it easier to read.

✅ **Verification:** Verified by running `flutter analyze test/widgets/app_card_test.dart` which now completes cleanly with 0 issues. The structural changes are purely removals of isolated variables.

✨ **Result:** Improved code health in the test suite without altering the testing coverage or behavior.

---
*PR created automatically by Jules for task [5594749462216507943](https://jules.google.com/task/5594749462216507943) started by @LeanBitLab*